### PR TITLE
ATLAS fields in OOPS and SABER

### DIFF
--- a/src/atlas_f/CMakeLists.txt
+++ b/src/atlas_f/CMakeLists.txt
@@ -151,6 +151,7 @@ ecbuild_add_library( TARGET atlas_f
         functionspace/atlas_functionspace_StructuredColumns_module.F90
         functionspace/atlas_functionspace_Spectral_module.F90
         field/atlas_FieldSet_module.F90
+        field/atlas_FieldSetBundle_module.F90
         field/atlas_State_module.F90
         field/atlas_Field_module.fypp
         grid/atlas_Grid_module.F90

--- a/src/atlas_f/atlas_module.F90
+++ b/src/atlas_f/atlas_module.F90
@@ -28,7 +28,7 @@ use atlas_FieldSet_module, only: &
     & atlas_FieldSet, &
     & atlas_FieldSet_registry
 use atlas_FieldSetBundle_module, only: &
-    & atlas_FieldSetBundle4D
+    & atlas_FieldSetBundle
 use atlas_State_module, only: &
     & atlas_State
 use atlas_JSON_module, only: &

--- a/src/atlas_f/atlas_module.F90
+++ b/src/atlas_f/atlas_module.F90
@@ -25,7 +25,8 @@ use atlas_Field_module, only: &
 use atlas_FunctionSpace_module, only: &
     & atlas_FunctionSpace
 use atlas_FieldSet_module, only: &
-    & atlas_FieldSet
+    & atlas_FieldSet, &
+    & atlas_FieldSet_registry
 use atlas_State_module, only: &
     & atlas_State
 use atlas_JSON_module, only: &

--- a/src/atlas_f/atlas_module.F90
+++ b/src/atlas_f/atlas_module.F90
@@ -27,6 +27,8 @@ use atlas_FunctionSpace_module, only: &
 use atlas_FieldSet_module, only: &
     & atlas_FieldSet, &
     & atlas_FieldSet_registry
+use atlas_FieldSetBundle_module, only: &
+    & atlas_FieldSetBundle4D
 use atlas_State_module, only: &
     & atlas_State
 use atlas_JSON_module, only: &

--- a/src/atlas_f/field/atlas_FieldSetBundle_module.F90
+++ b/src/atlas_f/field/atlas_FieldSetBundle_module.F90
@@ -1,0 +1,36 @@
+! (C) Copyright 2019 UCAR
+! 
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
+
+module atlas_FieldSetBundle_module
+
+use atlas_FieldSet_module
+use iso_c_binding
+
+implicit none
+
+type atlas_FieldSetBundle
+   type(atlas_FieldSet) :: fs
+   type(atlas_FieldSet),pointer :: ptr
+end type atlas_FieldSetBundle
+
+type atlas_FieldSetBundle4D
+  integer :: igrid                                  !> Index of the grid
+  integer :: nmga                                   !> Number of gridpoints (on a given MPI task)
+  integer :: nl0                                    !> Number of levels
+  integer :: nv                                     !> Number of variables
+  integer :: nts                                    !> Number of timeslots
+  real(kind=c_double),allocatable :: lon(:)         !> Longitude (in degrees: -180 to 180)
+  real(kind=c_double),allocatable :: lat(:)         !> Latitude (in degrees: -90 to 90)
+  real(kind=c_double),allocatable :: area(:)        !> Area (in m^2)
+  real(kind=c_double),allocatable :: vunit(:,:)     !> Vertical unit
+  logical,allocatable :: lmask(:,:)                 !> Mask
+
+  type(atlas_FieldSetBundle),allocatable :: afsb(:) !> ATLAS field sets
+end type atlas_FieldSetBundle4D
+
+private
+public :: atlas_FieldSetBundle4D
+
+end module atlas_FieldSetBundle_module

--- a/src/atlas_f/field/atlas_FieldSetBundle_module.F90
+++ b/src/atlas_f/field/atlas_FieldSetBundle_module.F90
@@ -15,22 +15,7 @@ type atlas_FieldSetBundle
    type(atlas_FieldSet),pointer :: ptr
 end type atlas_FieldSetBundle
 
-type atlas_FieldSetBundle4D
-  integer :: igrid                                  !> Index of the grid
-  integer :: nmga                                   !> Number of gridpoints (on a given MPI task)
-  integer :: nl0                                    !> Number of levels
-  integer :: nv                                     !> Number of variables
-  integer :: nts                                    !> Number of timeslots
-  real(kind=c_double),allocatable :: lon(:)         !> Longitude (in degrees: -180 to 180)
-  real(kind=c_double),allocatable :: lat(:)         !> Latitude (in degrees: -90 to 90)
-  real(kind=c_double),allocatable :: area(:)        !> Area (in m^2)
-  real(kind=c_double),allocatable :: vunit(:,:)     !> Vertical unit
-  logical,allocatable :: lmask(:,:)                 !> Mask
-
-  type(atlas_FieldSetBundle),allocatable :: afsb(:) !> ATLAS field sets
-end type atlas_FieldSetBundle4D
-
 private
-public :: atlas_FieldSetBundle4D
+public :: atlas_FieldSetBundle
 
 end module atlas_FieldSetBundle_module

--- a/src/atlas_f/field/atlas_FieldSetBundle_module.F90
+++ b/src/atlas_f/field/atlas_FieldSetBundle_module.F90
@@ -12,7 +12,7 @@ implicit none
 
 type atlas_FieldSetBundle
    type(atlas_FieldSet) :: fs
-   type(atlas_FieldSet),pointer :: ptr
+   type(atlas_FieldSet),pointer :: ptr => null()
 end type atlas_FieldSetBundle
 
 private

--- a/src/atlas_f/field/atlas_FieldSet_module.F90
+++ b/src/atlas_f/field/atlas_FieldSet_module.F90
@@ -17,7 +17,7 @@ implicit none
 
 private :: fckit_owned_object
 
-public :: atlas_FieldSet
+public :: atlas_FieldSet, atlas_FieldSet_registry
 
 private
 
@@ -64,11 +64,24 @@ interface atlas_FieldSet
 end interface
 
 !------------------------------------------------------------------------------
+#define LISTED_TYPE atlas_FieldSet
+
+! Linked list interface - defines registry_t type
+#include "atlas_f/internals/atlas_linkedList_i.f"
+
+! Global registry
+type(registry_t) :: atlas_FieldSet_registry
+
+!------------------------------------------------------------------------------
 
 
 !========================================================
 contains
 !========================================================
+! -----------------------------------------------------------------------------
+! Linked list implementation
+#include "atlas_f/internals/atlas_linkedList_c.f"
+
 ! -----------------------------------------------------------------------------
 ! FieldSet routines
 

--- a/src/atlas_f/internals/atlas_linkedList_c.f
+++ b/src/atlas_f/internals/atlas_linkedList_c.f
@@ -1,0 +1,112 @@
+! (C) Copyright 2009-2016 ECMWF.
+! 
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
+! In applying this licence, ECMWF does not waive the privileges and immunities 
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+!> Linked list implementation
+
+!> Linked list subroutines
+
+!> Initialize the linked list
+subroutine init_(self)
+ class(registry_t) :: self
+
+ !set count to zero and allocate the head of the list
+ if(.not.self%l_init.or..not.associated(self%head)) then
+  self%count = 0
+  allocate(self%head)
+  nullify(self%head%next)
+  self%l_init=.true.
+ endif
+end subroutine
+
+!> Add element to the linked list
+subroutine add_(self,key)
+ class(registry_t) :: self
+ integer           :: key
+
+ type(node_t), pointer :: next
+
+ !increase global counter and assign key
+ self%count = self%count+1
+ key = self%count
+
+ !allocate next element and assign key
+ allocate(next)
+ next%key = key
+
+ !move the head to the front of the list
+ next%next => self%head%next
+ self%head%next => next
+end subroutine
+
+!> Fetch element of the linked list by key
+subroutine get_(self,key,ptr)
+ class(registry_t)           :: self
+ integer                     :: key
+ type (LISTED_TYPE), pointer :: ptr
+
+ type(node_t), pointer :: next
+
+ !note that the list starts from self%head%next
+ next => self%head
+ ptr => NULL()
+
+ !sweep the linked list to find matching key
+ do while(associated(next))
+  next=>next%next
+  if(key.eq.next%key) then
+   ptr => next%element
+   exit
+  endif
+ enddo
+end subroutine
+
+!> Remove element of the linked list
+subroutine remove_(self,key)
+ class(registry_t) :: self
+ integer           :: key
+
+ type(node_t), pointer :: prev
+ type(node_t), pointer :: next
+
+ next => self%head%next
+ prev => NULL()
+
+ !sweep the linked list to find matching key, 
+ do while(associated(next))
+  if(key.eq.next%key) exit
+  prev => next
+  next => next%next
+ enddo
+ !reconnect the list
+ if(associated(next%next)) then
+  if(associated(prev)) then
+   prev%next => next%next
+  else
+   self%head%next=>next%next
+  endif
+ endif
+ !remove the node and set key to 0
+ if(associated(next)) deallocate(next)
+ key=0
+ return
+end subroutine
+
+!> Finalize the linked list, deallocate all nodes
+subroutine finalize_(self)
+ class(registry_t) :: self
+ type(node_t), pointer :: current
+ type(node_t), pointer :: next
+
+ !sweep the linked list and deallocate all nodes
+ next => self%head
+ do while(associated(next))
+  current => next
+  next => next%next
+  deallocate(current)
+ enddo
+end subroutine

--- a/src/atlas_f/internals/atlas_linkedList_i.f
+++ b/src/atlas_f/internals/atlas_linkedList_i.f
@@ -1,0 +1,31 @@
+! (C) Copyright 2009-2016 ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+!> Linked list interface block
+
+!> Node of a linked list
+type :: node_t
+integer           :: key
+  type(LISTED_TYPE) :: element
+
+  type(node_t), pointer  :: next => NULL()
+end type node_t
+
+!> Registry type
+type :: registry_t
+  logical               :: l_init = .false.
+  integer               :: count  = 0
+  type(node_t), pointer :: head   => NULL()
+
+contains
+  procedure :: init => init_
+  procedure :: finalize => finalize_
+  procedure :: add => add_
+  procedure :: get => get_
+  procedure :: remove => remove_
+end type registry_t


### PR DESCRIPTION
This PR introduces:
 -  linked lists to use the atlas_FieldSet in OOPS (QG model),
 - a new "atlas_FieldSetBundle" type (maybe we could find a better name) that is used a data container/pointer between OOPS and SABER.