### PR TITLE
Mesh without connectivity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ install:
     ### Install CMake
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       if [[ -z "$(ls -A ${DEPS_DIR}/cmake)" ]]; then
-        CMAKE_URL="https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz"
+        CMAKE_URL="https://cmake.org/files/v3.15.2/cmake-3.15.2-Linux-x86_64.tar.gz"
         mkdir -p ${DEPS_DIR}/cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
       fi
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [0.18.1] - 2019-08-10
+### Fixed
+- Match vertical structured interpolation to IFS
+- Fix in creating vertical dimension in StructuredColumns using interval
+- Fix in caching StructuredColumnsHaloExchange
+
 ## [0.18.0] - 2019-07-15
 ### Changed
 - Make grid hashes crossplatform
@@ -128,6 +134,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## 0.13.0 - 2018-02-16
 
 [Unreleased]: https://github.com/ecmwf/atlas/compare/master...develop
+[0.18.1]: https://github.com/ecmwf/atlas/compare/0.18.0...0.18.1
 [0.18.0]: https://github.com/ecmwf/atlas/compare/0.17.2...0.18.0
 [0.17.2]: https://github.com/ecmwf/atlas/compare/0.17.1...0.17.2
 [0.17.1]: https://github.com/ecmwf/atlas/compare/0.17.0...0.17.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ ecbuild_add_option( FEATURE EIGEN
                     DESCRIPTION "Use Eigen linear algebra library"
                     REQUIRED_PACKAGES Eigen3 )
 
-### Type for Global indices and unique point id's
+### Type for Global indices and unique point ids
 
 set( ATLAS_BITS_GLOBAL 64 )
 set( ATLAS_BITS_LOCAL 32 )
@@ -258,29 +258,9 @@ set( MIR_NEEDS_TRANSI TRUE CACHE BOOL "Deprecated" INTERNAL )
 
 include(CompileFlags)
 
-find_program (CLANG_TIDY_EXE NAMES "clang-tidy" )
-if( CLANG_TIDY_EXE )
-    message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
-endif()
-ecbuild_add_option( FEATURE CLANG_TIDY
-                    DESCRIPTION "Use clang-tidy"
-                    CONDITION CLANG_TIDY_EXE )
-if (HAVE_CLANG_TIDY)
-  set(CLANG_TIDY_CHECKS "-*,readability-braces-around-statements,redundant-string-init")
-  set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-checks=${CLANG_TIDY_CHECKS};-header-filter='${CMAKE_SOURCE_DIR}/*'")
-endif()
+include(FeatureClangTidy)
 
-find_program (INCLUDE_WHAT_YOU_USE_EXE NAMES "include-what-you-use" )
-if( INCLUDE_WHAT_YOU_USE_EXE )
-    message(STATUS "Found include-what-you-use: ${INCLUDE_WHAT_YOU_USE_EXE}" )
-endif()
-ecbuild_add_option( FEATURE INCLUDE_WHAT_YOU_USE
-                    DEFAULT OFF # Need clang compiler?
-                    DESCRIPTION "Use include-what-you-use clang-tool"
-                    CONDITION INCLUDE_WHAT_YOU_USE_EXE )
-if( HAVE_INCLUDE_WHAT_YOU_USE )
-    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${INCLUDE_WHAT_YOU_USE_EXE})
-endif()
+include(FeatureIncludeWhatYouUse)
 
 add_subdirectory( src )
 

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -6,5 +6,5 @@
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
 
-set  ( ${PROJECT_NAME}_VERSION_STR  "0.18.0" )
+set  ( ${PROJECT_NAME}_VERSION_STR  "0.18.1" )
 

--- a/cmake/FeatureClangTidy.cmake
+++ b/cmake/FeatureClangTidy.cmake
@@ -1,0 +1,26 @@
+set( CLANG_TIDY_SUPPORTED_COMPILERS     GNU Clang )
+
+set( CLANG_TIDY_DEFAULT OFF )
+foreach( _clang_tidy_supported_compiler ${CLANG_TIDY_SUPPORTED_COMPILERS} )
+  if( CMake_CXX_COMPILER_ID MATCHES _clang_tidy_supported_compiler )
+    set( CLANG_TIDY_DEFAULT ON )
+  endif()
+endforeach()
+
+find_program( CLANG_TIDY_EXE NAMES "clang-tidy" )
+if( CLANG_TIDY_EXE )
+    ecbuild_info( "Found clang-tidy: ${CLANG_TIDY_EXE}" )
+    if( NOT CLANG_TIDY_DEFAULT AND NOT DEFINED ENABLE_CLANG_TIDY )
+      ecbuild_info( "Feature CLANG_TIDY default OFF for compiler ${CMAKE_CXX_COMPILER_ID}" )
+    endif()
+endif()
+
+ecbuild_add_option( FEATURE CLANG_TIDY
+                    DEFAULT ${CLANG_TIDY_DEFAULT}
+                    DESCRIPTION "Use clang-tidy"
+                    CONDITION CLANG_TIDY_EXE )
+
+if (HAVE_CLANG_TIDY)
+  set(CLANG_TIDY_CHECKS "-*,readability-braces-around-statements,redundant-string-init")
+  set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-checks=${CLANG_TIDY_CHECKS};-header-filter='${CMAKE_SOURCE_DIR}/*'")
+endif()

--- a/cmake/FeatureIncludeWhatYouUse.cmake
+++ b/cmake/FeatureIncludeWhatYouUse.cmake
@@ -1,0 +1,13 @@
+find_program( INCLUDE_WHAT_YOU_USE_EXE NAMES "include-what-you-use" )
+if( INCLUDE_WHAT_YOU_USE_EXE )
+    ecbuild_info( "Found include-what-you-use: ${INCLUDE_WHAT_YOU_USE_EXE}" )
+endif()
+
+ecbuild_add_option( FEATURE INCLUDE_WHAT_YOU_USE
+                    DEFAULT OFF # Need clang compiler?
+                    DESCRIPTION "Use include-what-you-use clang-tool"
+                    CONDITION INCLUDE_WHAT_YOU_USE_EXE )
+
+if( HAVE_INCLUDE_WHAT_YOU_USE )
+    set( CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${INCLUDE_WHAT_YOU_USE_EXE} )
+endif()

--- a/src/atlas/mesh/actions/BuildConvexHull3D.cc
+++ b/src/atlas/mesh/actions/BuildConvexHull3D.cc
@@ -165,15 +165,21 @@ static void cgal_polyhedron_to_atlas_mesh( Mesh& mesh, Polyhedron_3& poly, Point
 #else
 
 struct Polyhedron_3 {
-    idx_t size_of_vertices() const { return 0; }
+    idx_t size_;
+    idx_t size_of_vertices() const { return size_;}
 };
 
 static Polyhedron_3* create_convex_hull_from_points( const std::vector<Point3>& pts ) {
-    throw_NotImplemented( "CGAL package not found -- Delaunay triangulation is disabled", Here() );
+    ATLAS_TRACE();
+
+    Polyhedron_3* poly = new Polyhedron_3();
+    poly->size_ = pts.size();
+
+    return poly;
 }
 
 static void cgal_polyhedron_to_atlas_mesh( Mesh& mesh, Polyhedron_3& poly, PointSet& points ) {
-    throw_NotImplemented( "CGAL package not found -- Delaunay triangulation is disabled", Here() );
+    atlas::Log::warning() << "WARNING: CGAL package not found -- Delaunay triangulation is disabled" << std::endl;
 }
 
 #endif


### PR DESCRIPTION
In this PR, I authorize the generation of a Delaunay mesh object without CGAL. No connectivity is computed, so the connectivity-specific functions (e.g. finding nearest neighbors) are not available. But the mesh object can be used to initialize a NodeColumns function space.