### PR TITLE
Atlas OpenMP dependency propogation and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ ecbuild_add_option( FEATURE TRANS
 set(Boost_USE_MULTITHREADED      ON )
 
 ecbuild_add_option( FEATURE TESSELATION
+                    DEFAULT OFF
                     DESCRIPTION "Support for unstructured mesh generation"
                     REQUIRED_PACKAGES "CGAL QUIET" "Boost 1.45.0" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,10 @@ endif()
 
 ### Eigen
 
+find_package( Eigen3 REQUIRED NO_MODULE HINTS
+    $ENV{Eigen3_ROOT} $ENV{EIGEN3_ROOT} $ENV{Eigen_ROOT} $ENV{EIGEN_ROOT}
+    $ENV{Eigen3_PATH} $ENV{EIGEN3_PATH} $ENV{Eigen_PATH} $ENV{EIGEN_PATH} )
+
 ecbuild_add_option( FEATURE EIGEN
                     DESCRIPTION "Use Eigen linear algebra library"
                     REQUIRED_PACKAGES Eigen3 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ endif()
 ecbuild_add_option(
   FEATURE GRIDTOOLS_STORAGE
   DESCRIPTION "Arrays internally use GridTools storage layer"
-  REQUIRED_PACKAGES "PROJECT gridtools_storage" )
+  REQUIRED_PACKAGES "PROJECT gridtools_storage QUIET" )
 
 if( ATLAS_HAVE_GRIDTOOLS_STORAGE )
 

--- a/atlas-import.cmake.in
+++ b/atlas-import.cmake.in
@@ -1,0 +1,10 @@
+# atlas-import.cmake
+# find_dependency calls for OOPS target dependencies
+
+include(CMakeFindDependencyMacro)
+
+if( @ATLAS_HAVE_EIGEN@ )
+    find_dependency( Eigen3 REQUIRED NO_MODULE HINTS
+        $ENV{Eigen3_ROOT} $ENV{EIGEN3_ROOT} $ENV{Eigen_ROOT} $ENV{EIGEN_ROOT}
+        $ENV{Eigen3_PATH} $ENV{EIGEN3_PATH} $ENV{Eigen_PATH} $ENV{EIGEN_PATH} )
+endif()

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -698,8 +698,6 @@ target_include_directories( atlas PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-
-
 if( ATLAS_HAVE_TESSELATION )
   target_link_libraries( atlas PRIVATE ${CGAL_LIBRARIES} )
   target_include_directories( atlas PRIVATE ${CGAL_INCLUDE_DIRS} )
@@ -712,6 +710,10 @@ endif()
 
 if( ATLAS_HAVE_EIGEN AND EIGEN3_INCLUDE_DIR )
   target_include_directories( atlas PUBLIC ${EIGEN3_INCLUDE_DIR} )
+  if( CMAKE_CXX_COMPILER_ID MATCHES Intel AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19)
+    #Problem linking with "__builtin_shuffle" is not supported
+    target_compile_definitions( atlas PRIVATE EIGEN_DONT_VECTORIZE=1 )
+  endif()
 endif()
 
 if( ATLAS_HAVE_OMP_CXX )

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -712,7 +712,8 @@ if( ATLAS_HAVE_EIGEN AND EIGEN3_INCLUDE_DIR )
   target_include_directories( atlas PUBLIC ${EIGEN3_INCLUDE_DIR} )
   if( CMAKE_CXX_COMPILER_ID MATCHES Intel AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19)
     #Problem linking with "__builtin_shuffle" is not supported
-    target_compile_definitions( atlas PRIVATE EIGEN_DONT_VECTORIZE=1 )
+    message(WARNING "[Intel/20.0 Eigen Bugfix] -DEIGEN_DONT_VECTORIZE=1")
+    target_compile_definitions( atlas PUBLIC EIGEN_DONT_VECTORIZE=1 )
   endif()
 endif()
 

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -715,7 +715,7 @@ if( ATLAS_HAVE_EIGEN AND EIGEN3_INCLUDE_DIR )
 endif()
 
 if( ATLAS_HAVE_OMP_CXX )
-  target_link_libraries( atlas PRIVATE OpenMP::OpenMP_CXX )
+  target_link_libraries( atlas PUBLIC OpenMP::OpenMP_CXX )
 endif()
 
 if( ATLAS_HAVE_GRIDTOOLS_STORAGE )

--- a/src/atlas_f/CMakeLists.txt
+++ b/src/atlas_f/CMakeLists.txt
@@ -49,7 +49,7 @@ function(generate_fortran_bindings output filename)
     OUTPUT ${outfile}
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/c2f.py ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
             -o ${outfile} -m ${_PAR_MODULE}
-            -t '{"idx_t":"${F_IDX}","gidx_t":"${F_GIDX}"}'
+            -t '{\"idx_t\":\"${F_IDX}\",\"gidx_t\":\"${F_GIDX}\"}'
     DEPENDS ${filename} )
   set_source_files_properties(${outfile} PROPERTIES GENERATED TRUE)
 endfunction()
@@ -194,7 +194,7 @@ target_link_libraries( atlas_f PUBLIC
   fckit )
 
 if( ATLAS_HAVE_OMP_Fortran )
-  target_link_libraries( atlas_f PRIVATE OpenMP::OpenMP_Fortran )
+  target_link_libraries( atlas_f PUBLIC OpenMP::OpenMP_Fortran )
 endif()
 
 target_include_directories( atlas_f PUBLIC

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -84,8 +84,10 @@ if( TRANSI_VERSION VERSION_LESS 0.6 )# transi not yet ported to CMake3
   include_directories( ${TRANSI_INCLUDE_DIRS} )
 endif()
 
+list(APPEND ATLAS_TEST_ENVIRONMENT "SLURM_OVERCOMMIT=1" )
+
 if( ATLAS_GRIDTOOLS_STORAGE_BACKEND_CUDA )
-  set( ATLAS_TEST_ENVIRONMENT "ATLAS_RUN_NGPUS=1" )
+  list(APPEND ATLAS_TEST_ENVIRONMENT "ATLAS_RUN_NGPUS=1" )
 endif()
 
 add_subdirectory( acc )


### PR DESCRIPTION
* Atlas uses OpenMP directives in its provided .h files.  Therefore OpenMP is a PUBLIC link dependency.
* Find gridtools quietly
* Fix problematic quote escapes
* Allow overcommit for testing when using srun on systems with SLURM installed.

Will also need `fv3-jedi/feature/openmp_headers` branch if building fv3-bundle with this PR.