### PR TITLE
Missing string header is an error under gcc-10.1.0

### DIFF
--- a/src/atlas/grid/Spacing.h
+++ b/src/atlas/grid/Spacing.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 #include <vector>
 
 #include "atlas/library/config.h"


### PR DESCRIPTION
This fix is necessary to build atlas with g++-10.  I have already submitted this patch upstream [ecmwf/atlas # 51](https://github.com/ecmwf/atlas/pull/51).

This is my first PR using the new cross-repo PR methodology and I'm not sure if I am doing this right.   I had to make two branches for the same PR.  One branch is necessary for the upstream ecmwf PR.  Even though this was a simple 1-line patch that merges cleanly, the branch for the PR must have the `ecmwf/develop` branch merged in or else it was not accepted upstream.  However, I still need a separate branch without `ecmwf/develop` merged in so that it matches `jcsda/develop` and can actually work with JEDI.  Since `jcsda/develop` doesn't normally match `ecmwf/develop` is there a way to do this without  the need for dual PRs?
