### PR TITLE
Missing string header is an error under gcc-10.1.0

### DIFF
--- a/src/atlas/grid/Spacing.h
+++ b/src/atlas/grid/Spacing.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 #include <vector>
 
 #include "atlas/library/config.h"


### PR DESCRIPTION
This hotfix is a backport of [ecmwf/atlas # 51](https://github.com/ecmwf/atlas/pull/51).  This is necessary for gcc-10 support as the missing header is an error.

Notes:
1. Hopefully this is more inline with how we want to handle these types of upstream PRs?
2. What is the difference with `release-stable` and `develop-jcsda`?
3. For the upstream PR I cannot add it to any epic or milestone because it is actually a PR to `ecmwf/atlas`.  One advantage of having a second local hotfix PR is that it will give a mechanism to track external contributions within the jcsda repo zenhub system.
