### PR TITLE
Feature/fspace repartition

### DIFF
--- a/cmake/atlas_compile_flags.cmake
+++ b/cmake/atlas_compile_flags.cmake
@@ -6,7 +6,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if( CMAKE_CXX_COMPILER_ID MATCHES Cray )

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -572,6 +572,8 @@ repartition/Repartition.h
 repartition/Repartition.cc
 repartition/detail/RepartitionImpl.h
 repartition/detail/RepartitionImpl.cc
+repartition/detail/RepartitionImplFactory.h
+repartition/detail/RepartitionImplFactory.cc
 repartition/detail/StructuredColumnsToStructuredColumns.h
 repartition/detail/StructuredColumnsToStructuredColumns.cc
 )

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -567,6 +567,14 @@ linalg/sparse/SparseMatrixMultiply_OpenMP.cc
 )
 
 
+list (APPEND atlas_repartition_srcs
+repartition/Repartition.h
+repartition/Repartition.cc
+repartition/detail/RepartitionImpl.h
+repartition/detail/RepartitionImpl.cc
+repartition/detail/StructuredColumnsToStructuredColumns.h
+repartition/detail/StructuredColumnsToStructuredColumns.cc
+)
 
 list( APPEND atlas_array_srcs
 array.h
@@ -708,6 +716,7 @@ if( SHORTCUT_COMPILATION )
   unset( atlas_field_srcs )
   unset( atlas_functionspace_srcs )
   unset( atlas_interpolation_srcs )
+  unset( atlas_repartition_srcs )
   unset( atlas_numerics_srcs )
   unset( atlas_output_srcs )
   unset( atlas_util_srcs )
@@ -722,6 +731,7 @@ list( APPEND source_list
   ${atlas_field_srcs}
   ${atlas_functionspace_srcs}
   ${atlas_interpolation_srcs}
+  ${atlas_repartition_srcs}
   ${atlas_numerics_srcs}
   ${atlas_output_srcs}
   ${atlas_util_srcs}

--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -574,6 +574,7 @@ repartition/detail/RepartitionImpl.h
 repartition/detail/RepartitionImpl.cc
 repartition/detail/RepartitionImplFactory.h
 repartition/detail/RepartitionImplFactory.cc
+repartition/detail/RepartitionUtils.h
 repartition/detail/StructuredColumnsToStructuredColumns.h
 repartition/detail/StructuredColumnsToStructuredColumns.cc
 )

--- a/src/atlas/repartition/Repartition.cc
+++ b/src/atlas/repartition/Repartition.cc
@@ -1,5 +1,5 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/atlas/repartition/Repartition.cc
+++ b/src/atlas/repartition/Repartition.cc
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "atlas/field/Field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/FunctionSpace.h"
+#include "atlas/repartition/Repartition.h"
+#include "atlas/repartition/detail/RepartitionImplFactory.h"
+
+namespace atlas {
+
+  // Use repartition implementation factory to make object.
+  Repartition::Repartition (
+    const FunctionSpace& sourceFunctionSpace,
+    const FunctionSpace& targetFunctionSpace) :
+    Handle (repartition::RepartitionImplFactory::build (
+      sourceFunctionSpace, targetFunctionSpace)) {}
+
+  void Repartition::execute(
+    const Field& sourceField, Field& targetField) const {
+
+    get()->execute(sourceField, targetField);
+    return;
+  }
+
+  void Repartition::execute(
+    const FieldSet& sourceFieldSet, FieldSet& targetFieldSet) const {
+
+    get()->execute(sourceFieldSet, targetFieldSet);
+    return;
+  }
+
+  FunctionSpace& Repartition::getSourceFunctionSpace () {
+
+    return get()->getSourceFunctionSpace();
+  }
+
+  const FunctionSpace& Repartition::getSourceFunctionSpace () const {
+
+    return get()->getSourceFunctionSpace();
+  }
+
+  FunctionSpace& Repartition::getTargetFunctionSpace () {
+
+    return get()->getTargetFunctionSpace();
+  }
+
+  const FunctionSpace& Repartition::getTargetFunctionSpace () const {
+
+    return get()->getTargetFunctionSpace();
+  }
+
+}

--- a/src/atlas/repartition/Repartition.cc
+++ b/src/atlas/repartition/Repartition.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
 #include "atlas/functionspace/FunctionSpace.h"

--- a/src/atlas/repartition/Repartition.cc
+++ b/src/atlas/repartition/Repartition.cc
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "atlas/field/Field.h"
 #include "atlas/field/FieldSet.h"
 #include "atlas/functionspace/FunctionSpace.h"

--- a/src/atlas/repartition/Repartition.h
+++ b/src/atlas/repartition/Repartition.h
@@ -1,5 +1,5 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/atlas/repartition/Repartition.h
+++ b/src/atlas/repartition/Repartition.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "atlas/repartition/detail/RepartitionImpl.h"
+#include "atlas/util/ObjectHandle.h"
+
+namespace atlas {
+  class Field;
+  class FieldSet;
+  class FunctionSpace;
+}
+
+namespace atlas {
+
+  // Object handle class for reparitioner
+  class Repartition :
+    public util::ObjectHandle<repartition::RepartitionImpl> {
+
+  public:
+
+    using Handle::Handle;
+
+    Repartition () = default;
+
+    // Set up repartitioner form source to target function space.
+    Repartition (
+      const FunctionSpace& sourceFunctionSpace,
+      const FunctionSpace& targetFunctionSpace);
+
+    void execute (const Field& sourceField, Field& targetField) const;
+    void execute (
+      const FieldSet& sourceFieldSet, FieldSet& targetFieldSet) const;
+
+    FunctionSpace& getSourceFunctionSpace ();
+    const FunctionSpace& getSourceFunctionSpace () const;
+    FunctionSpace& getTargetFunctionSpace ();
+    const FunctionSpace& getTargetFunctionSpace () const;
+
+  };
+
+}

--- a/src/atlas/repartition/Repartition.h
+++ b/src/atlas/repartition/Repartition.h
@@ -1,3 +1,10 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #pragma once
 
 #include "atlas/repartition/detail/RepartitionImpl.h"
@@ -11,7 +18,10 @@ namespace atlas {
 
 namespace atlas {
 
-  // Object handle class for reparitioner
+  /// \brief    Base repartitioner class.
+  ///
+  /// \details  Class to map two function spaces with the same grid but
+  ///           different partitioners.
   class Repartition :
     public util::ObjectHandle<repartition::RepartitionImpl> {
 
@@ -19,21 +29,49 @@ namespace atlas {
 
     using Handle::Handle;
 
-    Repartition () = default;
-
-    // Set up repartitioner form source to target function space.
-    Repartition (
+    /// \brief    Constructs and initialises the repartitioner.
+    ///
+    /// \details  Initialises class to copy fields from a source function space
+    ///           to fields from a target functionspace. The grids of source and
+    ///           target function space must match.
+    ///
+    /// \param[in]  sourceFunctionSpace  Function space of source fields.
+    /// \param[in]  targetFunctionSpace  Function space of target fields.
+    Repartition(
       const FunctionSpace& sourceFunctionSpace,
       const FunctionSpace& targetFunctionSpace);
 
-    void execute (const Field& sourceField, Field& targetField) const;
-    void execute (
+    /// \brief    Maps source field to target field.
+    ///
+    /// \details  Transfers data from source field to target field. Function
+    ///           space of source field must match sourceFunctionSpace. Same
+    ///           applies to target field.
+    ///
+    /// \param[in]  sourceField  input field matching sourceFunctionSpace.
+    /// \param[out] targetField  output field matching targetFunctionSpace.
+    void execute(const Field& sourceField, Field& targetField) const;
+
+    /// \brief    Repartitions source field set to target fields set.
+    ///
+    /// \details  Transfers source field set to target field set via multiple
+    ///           invocations of execute(sourceField, targetField).
+    ///
+    /// \param[in]  sourceFieldSet  input field set.
+    /// \param[out] targetFieldSet  output field set.
+    void execute(
       const FieldSet& sourceFieldSet, FieldSet& targetFieldSet) const;
 
-    FunctionSpace& getSourceFunctionSpace ();
-    const FunctionSpace& getSourceFunctionSpace () const;
-    FunctionSpace& getTargetFunctionSpace ();
-    const FunctionSpace& getTargetFunctionSpace () const;
+    /// \brief  Get reference to source function space.
+    FunctionSpace& getSourceFunctionSpace();
+
+    /// \brief  Get const reference to source function space.
+    const FunctionSpace& getSourceFunctionSpace() const;
+
+    /// \brief  Get reference to taget function space.
+    FunctionSpace& getTargetFunctionSpace();
+
+    /// \brief  Get const reference to target function space.
+    const FunctionSpace& getTargetFunctionSpace() const;
 
   };
 

--- a/src/atlas/repartition/detail/RepartitionImpl.cc
+++ b/src/atlas/repartition/detail/RepartitionImpl.cc
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/repartition/detail/RepartitionImpl.h"

--- a/src/atlas/repartition/detail/RepartitionImpl.cc
+++ b/src/atlas/repartition/detail/RepartitionImpl.cc
@@ -1,3 +1,10 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/repartition/detail/RepartitionImpl.h"
 
@@ -10,23 +17,23 @@ namespace atlas {
       const FunctionSpace& source, const FunctionSpace& target) :
       sourceFunctionSpace_(source), targetFunctionSpace_(target) {}
 
-    RepartitionImpl::~RepartitionImpl () {}
+    RepartitionImpl::~RepartitionImpl() {}
 
     // Getters.
 
-    FunctionSpace& RepartitionImpl::getSourceFunctionSpace () {
+    FunctionSpace& RepartitionImpl::getSourceFunctionSpace() {
       return sourceFunctionSpace_;
     }
 
-    const FunctionSpace& RepartitionImpl::getSourceFunctionSpace () const {
+    const FunctionSpace& RepartitionImpl::getSourceFunctionSpace() const {
       return sourceFunctionSpace_;
     }
 
-    FunctionSpace& RepartitionImpl::getTargetFunctionSpace () {
+    FunctionSpace& RepartitionImpl::getTargetFunctionSpace() {
       return targetFunctionSpace_;
     }
 
-    const FunctionSpace& RepartitionImpl::getTargetFunctionSpace () const {
+    const FunctionSpace& RepartitionImpl::getTargetFunctionSpace() const {
       return targetFunctionSpace_;
     }
 

--- a/src/atlas/repartition/detail/RepartitionImpl.cc
+++ b/src/atlas/repartition/detail/RepartitionImpl.cc
@@ -1,0 +1,34 @@
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/repartition/detail/RepartitionImpl.h"
+
+namespace atlas {
+  namespace repartition {
+
+    // Constructors/destructors.
+
+    RepartitionImpl::RepartitionImpl (
+      const FunctionSpace& source, const FunctionSpace& target) :
+      sourceFunctionSpace_(source), targetFunctionSpace_(target) {}
+
+    RepartitionImpl::~RepartitionImpl () {}
+
+    // Getters.
+
+    FunctionSpace& RepartitionImpl::getSourceFunctionSpace () {
+      return sourceFunctionSpace_;
+    }
+
+    const FunctionSpace& RepartitionImpl::getSourceFunctionSpace () const {
+      return sourceFunctionSpace_;
+    }
+
+    FunctionSpace& RepartitionImpl::getTargetFunctionSpace () {
+      return targetFunctionSpace_;
+    }
+
+    const FunctionSpace& RepartitionImpl::getTargetFunctionSpace () const {
+      return targetFunctionSpace_;
+    }
+
+  }
+}

--- a/src/atlas/repartition/detail/RepartitionImpl.h
+++ b/src/atlas/repartition/detail/RepartitionImpl.h
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #pragma once
 

--- a/src/atlas/repartition/detail/RepartitionImpl.h
+++ b/src/atlas/repartition/detail/RepartitionImpl.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "atlas/util/Object.h"
+#include "atlas/functionspace.h"
+
+namespace atlas {
+  class Field;
+  class FieldSet;
+  class FunctionSpace;
+}
+
+namespace atlas {
+  namespace repartition {
+
+    // Abstract class for repartitioner implementation.
+    class RepartitionImpl : public util::Object {
+
+    public:
+
+      virtual ~RepartitionImpl () = 0;
+
+      virtual void execute (
+        const Field& sourceField, Field& targetField) const = 0;
+      virtual void execute (
+        const FieldSet& sourceFieldSet, FieldSet& targetFieldSet) const = 0;
+
+      FunctionSpace& getSourceFunctionSpace ();
+      const FunctionSpace& getSourceFunctionSpace () const;
+      FunctionSpace& getTargetFunctionSpace ();
+      const FunctionSpace& getTargetFunctionSpace () const;
+
+    protected:
+
+      RepartitionImpl (
+        const FunctionSpace& source, const FunctionSpace& target);
+
+    private:
+
+      FunctionSpace sourceFunctionSpace_;
+      FunctionSpace targetFunctionSpace_;
+
+    };
+
+  }
+}

--- a/src/atlas/repartition/detail/RepartitionImpl.h
+++ b/src/atlas/repartition/detail/RepartitionImpl.h
@@ -1,3 +1,10 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #pragma once
 
 #include "atlas/util/Object.h"
@@ -12,22 +19,33 @@ namespace atlas {
 namespace atlas {
   namespace repartition {
 
-    // Abstract class for repartitioner implementation.
+    /// \brief  Abstract base class for repartitioner implementation.
     class RepartitionImpl : public util::Object {
 
     public:
 
-      virtual ~RepartitionImpl () = 0;
+      /// \brief  Virtual destructor.
+      virtual ~RepartitionImpl() = 0;
 
-      virtual void execute (
+      /// \brief  Maps source field to target field.
+      virtual void execute(
         const Field& sourceField, Field& targetField) const = 0;
-      virtual void execute (
+
+      /// \brief  Maps source field set to target field set.
+      virtual void execute(
         const FieldSet& sourceFieldSet, FieldSet& targetFieldSet) const = 0;
 
-      FunctionSpace& getSourceFunctionSpace ();
-      const FunctionSpace& getSourceFunctionSpace () const;
-      FunctionSpace& getTargetFunctionSpace ();
-      const FunctionSpace& getTargetFunctionSpace () const;
+      /// \brief  Get reference to source function space.
+      FunctionSpace& getSourceFunctionSpace();
+
+      /// \brief  Get const reference to source function space.
+      const FunctionSpace& getSourceFunctionSpace() const;
+
+      /// \brief  Get reference to taget function space.
+      FunctionSpace& getTargetFunctionSpace();
+
+      /// \brief  Get const reference to target function space.
+      const FunctionSpace& getTargetFunctionSpace() const;
 
     protected:
 

--- a/src/atlas/repartition/detail/RepartitionImplFactory.cc
+++ b/src/atlas/repartition/detail/RepartitionImplFactory.cc
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #include "atlas/functionspace/StructuredColumns.h"
 #include "atlas/repartition/detail/RepartitionImplFactory.h"

--- a/src/atlas/repartition/detail/RepartitionImplFactory.cc
+++ b/src/atlas/repartition/detail/RepartitionImplFactory.cc
@@ -1,6 +1,15 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #include "atlas/functionspace/StructuredColumns.h"
 #include "atlas/repartition/detail/RepartitionImplFactory.h"
 #include "atlas/repartition/detail/StructuredColumnsToStructuredColumns.h"
+
+#include "eckit/exception/Exceptions.h"
 
 namespace atlas {
   namespace repartition {
@@ -9,17 +18,21 @@ namespace atlas {
       const FunctionSpace& sourceFunctionSpace,
       const FunctionSpace& targetFunctionSpace) {
 
-      if (sourceFunctionSpace->type() == StructuredColumns::type() &&
-          targetFunctionSpace->type() == StructuredColumns::type()) {
 
-        std::cout << "Making StructuredColumnsToStructuredColumns" << std::endl;
+      if (sourceFunctionSpace->type() ==
+        functionspace::StructuredColumns::type() &&
+        targetFunctionSpace->type() ==
+        functionspace::StructuredColumns::type()) {
+
         return new StructuredColumnsToStructuredColumns (
           sourceFunctionSpace, targetFunctionSpace);
       }
       else {
 
-        std::cout << "Unknown source " + sourceFunctionSpace->type() << std::endl;
-        std::cout << "Unknown target " + targetFunctionSpace->type() << std::endl;
+        throw eckit::NotImplemented(
+          "No implementation for source function space " +
+          sourceFunctionSpace->type() + " and target functionspace " +
+          targetFunctionSpace->type(), Here());
         return nullptr;
 
       }

--- a/src/atlas/repartition/detail/RepartitionImplFactory.cc
+++ b/src/atlas/repartition/detail/RepartitionImplFactory.cc
@@ -12,6 +12,7 @@ namespace atlas {
       if (sourceFunctionSpace->type() == StructuredColumns::type() &&
           targetFunctionSpace->type() == StructuredColumns::type()) {
 
+        std::cout << "Making StructuredColumnsToStructuredColumns" << std::endl;
         return new StructuredColumnsToStructuredColumns (
           sourceFunctionSpace, targetFunctionSpace);
       }
@@ -19,9 +20,9 @@ namespace atlas {
 
         std::cout << "Unknown source " + sourceFunctionSpace->type() << std::endl;
         std::cout << "Unknown target " + targetFunctionSpace->type() << std::endl;
+        return nullptr;
+
       }
-
-
     }
 
   }

--- a/src/atlas/repartition/detail/RepartitionImplFactory.cc
+++ b/src/atlas/repartition/detail/RepartitionImplFactory.cc
@@ -1,0 +1,29 @@
+#include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/repartition/detail/RepartitionImplFactory.h"
+#include "atlas/repartition/detail/StructuredColumnsToStructuredColumns.h"
+
+namespace atlas {
+  namespace repartition {
+
+    RepartitionImpl* RepartitionImplFactory::build (
+      const FunctionSpace& sourceFunctionSpace,
+      const FunctionSpace& targetFunctionSpace) {
+
+      if (sourceFunctionSpace->type() == StructuredColumns::type() &&
+          targetFunctionSpace->type() == StructuredColumns::type()) {
+
+        return new StructuredColumnsToStructuredColumns (
+          sourceFunctionSpace, targetFunctionSpace);
+      }
+      else {
+
+        std::cout << "Unknown source " + sourceFunctionSpace->type() << std::endl;
+        std::cout << "Unknown target " + targetFunctionSpace->type() << std::endl;
+      }
+
+
+    }
+
+  }
+}
+

--- a/src/atlas/repartition/detail/RepartitionImplFactory.h
+++ b/src/atlas/repartition/detail/RepartitionImplFactory.h
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #pragma once
 

--- a/src/atlas/repartition/detail/RepartitionImplFactory.h
+++ b/src/atlas/repartition/detail/RepartitionImplFactory.h
@@ -1,3 +1,10 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
 #pragma once
 
 namespace atlas {
@@ -12,13 +19,13 @@ namespace atlas {
 namespace atlas {
   namespace repartition{
 
-    // Factory class to select correct concrete repartitioner.
+    /// \brief  Factory class to select correct concrete repartitioner.
     class RepartitionImplFactory {
 
     public:
 
-      // Selection based on source and target FunctionSpaces.
-      static RepartitionImpl* build (
+      /// \brief  Selection based on source and target function spaces.
+      static RepartitionImpl* build(
         const FunctionSpace& sourceFunctionSpace,
         const FunctionSpace& targetFunctionSpace);
     };

--- a/src/atlas/repartition/detail/RepartitionImplFactory.h
+++ b/src/atlas/repartition/detail/RepartitionImplFactory.h
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace atlas {
+
+  class FunctionSpace;
+
+  namespace repartition {
+    class RepartitionImpl;
+  }
+}
+
+namespace atlas {
+  namespace repartition{
+
+    // Factory class to select correct concrete repartitioner.
+    class RepartitionImplFactory {
+
+    public:
+
+      // Selection based on source and target FunctionSpaces.
+      static RepartitionImpl* build (
+        const FunctionSpace& sourceFunctionSpace,
+        const FunctionSpace& targetFunctionSpace);
+    };
+
+  }
+}

--- a/src/atlas/repartition/detail/RepartitionUtils.h
+++ b/src/atlas/repartition/detail/RepartitionUtils.h
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #pragma once
 

--- a/src/atlas/repartition/detail/RepartitionUtils.h
+++ b/src/atlas/repartition/detail/RepartitionUtils.h
@@ -1,0 +1,94 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#pragma once
+
+#include <string>
+#include <typeinfo>
+
+#include "atlas/field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/functionspace/detail/FunctionSpaceImpl.h"
+
+#include "eckit/exception/Exceptions.h"
+
+namespace atlas {
+  namespace repartition {
+
+    using functionspace::FunctionSpaceImpl;
+
+    /// \brief  Check function space can be cast to FunctionSpaceType.
+    template <typename FunctionSpaceType>
+    void tryCast(const FunctionSpaceImpl* const functionSpacePtr,
+      const std::string& varName) {
+
+      // Check if cast failed.
+      if (!(functionSpacePtr->cast<FunctionSpaceType>())) {
+         throw eckit::BadCast("Cannot cast " + varName + " to " +
+         typeid(FunctionSpaceType).name() , Here());
+      }
+
+      return;
+    }
+
+    /// \brief  Check grids associated with two function spaces match.
+    template <typename FunctionSpaceType>
+    void checkGrids(const FunctionSpaceImpl* const functionSpacePtrA,
+      const FunctionSpaceImpl* const functionSpacePtrB,
+      const std::string& varNameA, const std::string& varNameB) {
+
+      // Cast function spaces.
+      const auto* const castPtrA = functionSpacePtrA->cast<FunctionSpaceType>();
+      const auto* const castPtrB = functionSpacePtrB->cast<FunctionSpaceType>();
+
+      // Check casts.
+      tryCast<FunctionSpaceType>(castPtrA, varNameA);
+      tryCast<FunctionSpaceType>(castPtrB, varNameB);
+
+      // Check grids match.
+      const auto gridNameA = castPtrA->grid().name();
+      const auto gridNameB = castPtrB->grid().name();
+
+      if (gridNameA != gridNameB) {
+
+        throw eckit::BadValue("Grids do not match.\n" +
+          varNameA + "->grid() is type " + gridNameA + "\n" +
+          varNameB + "->grid() is type " + gridNameB, Here());
+      }
+
+      return;
+    }
+
+    /// \brief  Check fields have the same data type.
+    void checkFieldDataType(const Field& fieldA, const Field& fieldB,
+      const std::string& varnameA, const std::string& varnameB) {
+
+      // Check fields have the same data type.
+      if (fieldA.datatype() != fieldB.datatype()) {
+        throw eckit::BadValue("Fields have different data types.\n" +
+          varnameA + " has data type " + fieldA.datatype().str() + "\n" +
+          varnameB + " has data type " + fieldB.datatype().str(), Here());
+      }
+
+      return;
+    }
+
+    /// \brief  Check field sets the same size.
+    void checkFieldSetSize(const FieldSet& fieldSetA, const FieldSet& fieldSetB,
+      const std::string& varnameA, const std::string& varnameB) {
+
+      // Check fields have the same data type.
+      if (fieldSetA.size() != fieldSetB.size()) {
+        throw eckit::BadValue("Field sets have different data types.\n" +
+          varnameA + " has size " + std::to_string(fieldSetA.size()) + "\n" +
+          varnameB + " has size " + std::to_string(fieldSetB.size()), Here());
+      }
+
+      return;
+    }
+  }
+}

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #include <algorithm>
 #include <numeric>

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
@@ -1,3 +1,7 @@
+#include <algorithm>
+#include <numeric>
+
+#include "atlas/array/MakeView.h"
 #include "atlas/field.h"
 #include "atlas/field/FieldSet.h"
 #include "atlas/parallel/mpi/mpi.h"
@@ -6,37 +10,282 @@
 namespace atlas {
   namespace repartition {
 
-    StructuredColumnsToStructuredColumns::StructuredColumnsToStructuredColumns (
+    // Helper function forward declarations.
+    namespace  {
+      std::vector<indexRange>
+        getIndexRange(const StructuredColumns& functionSpace);
+
+      indexRange getIntersection(const indexRange& indexRangeA,
+        const indexRange& indexRangeB);
+
+      std::vector<indexRange> getIntersections(const indexRange& indexRangeA,
+        const std::vector<indexRange>& indexRangesB);
+
+      std::pair<std::vector<int>, std::vector<int>>
+        getCountsDisplacements(const std::vector<indexRange>& indexRanges);
+
+      std::vector<indexRange> trimIntersections(
+        const std::vector<indexRange>& intersections,
+        const std::vector<int>& counts);
+
+      template <typename fieldType>
+      void performAllToAll(const Field& sourceField, const Field& targetField);
+    }
+
+
+    StructuredColumnsToStructuredColumns::StructuredColumnsToStructuredColumns(
       const FunctionSpace& sourceFunctionSpace,
       const FunctionSpace& targetFunctionSpace) :
-      RepartitionImpl (sourceFunctionSpace, targetFunctionSpace),
-      sourceStructuredColumns_ (
-        dynamic_cast<StructuredColumns*> (&getSourceFunctionSpace ())),
-      targetStructuredColumns_ (
-        dynamic_cast<StructuredColumns*> (&getTargetFunctionSpace ())) {
+      RepartitionImpl(sourceFunctionSpace, targetFunctionSpace),
+      sourceStructuredColumns_(getSourceFunctionSpace()),
+      targetStructuredColumns_(getTargetFunctionSpace()) {
 
-      std::cout << "Constructor on MPI rank " << mpi::rank () << std::endl;
+      // Get MPI rank.
+      auto mpiRank = static_cast<size_t>(mpi::comm().rank());
 
-      // Communicate
+      // Get ranges of source function spaces.
+      auto sourceRanges = getIndexRange(sourceStructuredColumns_);
+
+      // Get ranges of target function spaces.
+      auto targetRanges = getIndexRange(targetStructuredColumns_);
+
+      // Calculate intersection between this source range and all target ranges.
+      sendIntersections_ =
+        getIntersections(sourceRanges[mpiRank], targetRanges);
+
+      // Calculate intersection between this target range and all source ranges.
+      receiveIntersections_ =
+        getIntersections(targetRanges[mpiRank], sourceRanges);
+
+      // Get send counts and displacements.
+      std::tie(sendCounts_, sendDisplacements_) =
+        getCountsDisplacements(sendIntersections_);
+
+      // Get receive counts and displacements.
+      std::tie(receiveCounts_, receiveDisplacements_) =
+        getCountsDisplacements(receiveIntersections_);
+
+      // Trim off empty send intersections.
+      sendIntersections_ =
+        trimIntersections(sendIntersections_, sendCounts_);
+
+      // Trim off empty receive intersections.
+      receiveIntersections_ =
+        trimIntersections(receiveIntersections_, receiveCounts_);
+
+      if (mpiRank == 0) {
+
+          std::for_each(sendIntersections_.begin(), sendIntersections_.end(),
+            [&](indexRange& rangeElem){
+              std::cout << std::endl << "MPI rank " << mpiRank << std::endl;
+              std::cout << rangeElem.jBeginEnd.first << " " << rangeElem.jBeginEnd.second << std::endl;
+              std::cout << std::endl;
+              std::for_each(rangeElem.iBeginEnd.begin(),rangeElem.iBeginEnd.end(),
+                [](idxPair elem){
+                std::cout << elem.first << " " << elem.second << std::endl;
+              });
+            });
+        std::cout << sendCounts_ << std::endl;
+      }
 
       return;
     }
 
-    void StructuredColumnsToStructuredColumns::execute (
-      const Field& sourceField, Field& targetField) const {
+    void StructuredColumnsToStructuredColumns::execute(
+      const Field& sourceField, Field& targetField ) const {
 
-      std::cout << "Field execute on MPI rank " << mpi::rank () << std::endl;
+      std::cout<< "Field execute on MPI rank " << mpi::rank()<< std::endl;
 
       return;
     }
 
-    void StructuredColumnsToStructuredColumns::execute (
+    void StructuredColumnsToStructuredColumns::execute(
       const FieldSet& sourceField, FieldSet& targetField) const {
 
-      std::cout << "FieldSet execute on MPI rank " << mpi::rank () << std::endl;
+      std::cout<< "FieldSet execute on MPI rank " << mpi::rank()<< std::endl;
 
       return;
     }
 
+
+    // Helper function definitions.
+    namespace  {
+
+      // Communicate index range of function spaces to all PEs
+      std::vector<indexRange> getIndexRange(
+        const StructuredColumns& functionSpace) {
+
+        // Get MPI communicator size.
+        auto mpiSize = static_cast<size_t>(mpi::comm().size());
+
+        // Set send buffer for j range.
+        auto jSendBuffer = idxPair(
+          functionSpace.j_begin(), functionSpace.j_end());
+
+        // Set receive buffer for j range.
+        auto jReceiveBuffer = idxPairVector(mpiSize);
+
+        // Perform all gather.
+        mpi::comm().allGather(
+          jSendBuffer, jReceiveBuffer.begin(), jReceiveBuffer.end());
+
+        // Set send buffer for i range.
+        auto iSendBuffer = idxPairVector();
+        std::generate_n(std::back_inserter(iSendBuffer),
+          jSendBuffer.second - jSendBuffer.first,
+          [&, j = jSendBuffer.first]() mutable
+          {
+            auto iElem = idxPair(
+              functionSpace.i_begin(j), functionSpace.i_end(j));
+            ++j;
+            return iElem;
+          });
+
+        // Set receive counts for i range.
+        auto iReceiveCounts = std::vector<int>{};
+        std::transform(jReceiveBuffer.begin(), jReceiveBuffer.end(),
+          std::back_inserter(iReceiveCounts),
+          [](const idxPair& jElem){
+            return static_cast<int>(jElem.second - jElem.first);
+          });
+
+        // Set receive displacements for i range.
+        auto iReceiveDisplacements = std::vector<int>{1};
+        std::partial_sum(iReceiveCounts.begin(), iReceiveCounts.end() - 1,
+          std::back_inserter(iReceiveDisplacements));
+
+        // Set receive buffer for i range.
+        auto iReceiveBuffer = idxPairVector(static_cast<size_t>(
+          iReceiveDisplacements.back() + iReceiveCounts.back()));
+
+        // Perform all gather.
+        mpi::comm().allGatherv(
+          iSendBuffer.begin(), iSendBuffer.end(), iReceiveBuffer.begin(),
+          iReceiveCounts.data(), iReceiveDisplacements.data());
+
+        // Make vector of indexRange structs.
+        auto indexRanges = std::vector<indexRange>{};
+        std::generate_n(std::back_inserter(indexRanges), mpiSize,
+          [&, i = size_t{0}]() mutable {
+
+            auto rangeElem = indexRange{};
+            rangeElem.jBeginEnd = jReceiveBuffer[i];
+
+            auto iBegin = iReceiveBuffer.begin() + iReceiveDisplacements[i];
+            auto iEnd = iBegin + iReceiveCounts[i];
+            std::copy(iBegin, iEnd, std::back_inserter(rangeElem.iBeginEnd));
+
+            ++i;
+            return rangeElem;
+          });
+
+        return indexRanges;
+      }
+
+      // Calculate the intersection between two index ranges.
+      indexRange getIntersection(const indexRange& indexRangeA,
+        const indexRange& indexRangeB) {
+
+        // Declare result.
+        auto intersection = indexRange{};
+
+        // get j intersection range.
+        intersection.jBeginEnd = idxPair(
+          std::max(indexRangeA.jBeginEnd.first, indexRangeB.jBeginEnd.first),
+          std::min(indexRangeA.jBeginEnd.second, indexRangeB.jBeginEnd.second));
+
+        // get i intersection range.
+        if (intersection.jBeginEnd.first < intersection.jBeginEnd.second) {
+
+          // get iterators.
+          auto iBeginA = indexRangeA.iBeginEnd.begin()
+            + intersection.jBeginEnd.first - indexRangeA.jBeginEnd.first;
+          auto iBeginB = indexRangeB.iBeginEnd.begin()
+            + intersection.jBeginEnd.first - indexRangeB.jBeginEnd.first;
+          auto iEndA = indexRangeA.iBeginEnd.end()
+            + intersection.jBeginEnd.second - indexRangeA.jBeginEnd.second;
+
+          std::transform(
+            iBeginA, iEndA, iBeginB, std::back_inserter(intersection.iBeginEnd),
+            [](const idxPair& iElemA, const idxPair& iElemB){
+              return idxPair(std::max(iElemA.first, iElemB.first),
+                std::min(iElemA.second, iElemB.second));
+            });
+        }
+        return intersection;
+      }
+
+      // Calculate the intersections between an index range and a vector of
+      // index ranges.
+      std::vector<indexRange> getIntersections(const indexRange& indexRangeA,
+        const std::vector<indexRange>& indexRangesB) {
+
+        // Declare result.
+        auto intersections = std::vector<indexRange>{};
+
+        // Get MPI comm size.
+        auto mpiSize = mpi::comm().size();
+
+        // Calculate intersection between index ranges.
+        std::generate_n(std::back_inserter(intersections), mpiSize,
+          [&, i = size_t{0}]() mutable {
+            return getIntersection(indexRangeA, indexRangesB[i++]);
+          });
+
+        return intersections;
+      }
+
+      // Get the count and displacement arrays needed for an allToAll MPI
+      // communication.
+      std::pair<std::vector<int>, std::vector<int>>
+        getCountsDisplacements(const std::vector<indexRange>& indexRanges) {
+
+        // Declare result.
+        auto countsDisplacements =
+          std::pair<std::vector<int>, std::vector<int>>{};
+
+        // Count the number of elements in each index range.
+        std::transform(indexRanges.begin(), indexRanges.end(),
+          std::back_inserter(countsDisplacements.first),
+          [](const indexRange& rangeElem){
+
+            // Accumulate size of positive i range.
+            int count = std::accumulate(rangeElem.iBeginEnd.begin(),
+              rangeElem.iBeginEnd.end(), 0,
+              [](const int& cumulant, const idxPair& iElem) -> int {
+                return cumulant + std::max(iElem.second - iElem.first, 0);
+              });
+
+            return count;
+          });
+
+        // Calculate displacements from counts.
+        countsDisplacements.second.push_back(0);
+        std::partial_sum(countsDisplacements.first.begin(),
+          countsDisplacements.first.end() - 1,
+          std::back_inserter(countsDisplacements.second));
+
+        return countsDisplacements;
+      }
+
+      // Produce a trimmed vector of index ranges with no zero-sized ranges.
+      std::vector<indexRange> trimIntersections(
+        const std::vector<indexRange>& intersections,
+        const std::vector<int>& counts) {
+
+        // Declare result.
+        auto trimmedIntersections = std::vector<indexRange>{};
+
+        // Remove intersections with no elements.
+        std::for_each(intersections.begin(), intersections.end(),
+          [&, i = size_t{0}](const indexRange& intersection) mutable {
+            if (counts[i++]) trimmedIntersections.push_back(intersection);
+            return;
+          });
+
+        return trimmedIntersections;
+      }
+
+    }
   }
 }

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
@@ -1,0 +1,39 @@
+#include "atlas/field.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/repartition/detail/StructuredColumnsToStructuredColumns.h"
+
+namespace atlas {
+  namespace repartition {
+
+    StructuredColumnsToStructuredColumns::StructuredColumnsToStructuredColumns (
+      const FunctionSpace& sourceFunctionSpace,
+      const FunctionSpace& targetFunctionSpace) :
+      RepartitionImpl (sourceFunctionSpace, targetFunctionSpace),
+      sourceStructuredColumns_ (
+        dynamic_cast<StructuredColumns&> (getSourceFunctionSpace ())),
+      targetStructuredColumns_ (
+        dynamic_cast<StructuredColumns&> (getTargetFunctionSpace ())) {
+
+      std::cout << "Constructor on MPI rank " << mpi::rank () << std::endl;
+
+      return;
+    }
+
+    void StructuredColumnsToStructuredColumns::execute (
+      const Field& sourceField, Field& targetField) const {
+
+      std::cout << "Field execute on MPI rank " << mpi::rank () << std::endl;
+
+      return;
+    }
+
+    void StructuredColumnsToStructuredColumns::execute (
+      const FieldSet& sourceField, FieldSet& targetField) const {
+
+      std::cout << "FieldSet execute on MPI rank " << mpi::rank () << std::endl;
+
+      return;
+    }
+
+  }
+}

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.cc
@@ -1,5 +1,6 @@
 #include "atlas/field.h"
 #include "atlas/field/FieldSet.h"
+#include "atlas/parallel/mpi/mpi.h"
 #include "atlas/repartition/detail/StructuredColumnsToStructuredColumns.h"
 
 namespace atlas {
@@ -10,11 +11,13 @@ namespace atlas {
       const FunctionSpace& targetFunctionSpace) :
       RepartitionImpl (sourceFunctionSpace, targetFunctionSpace),
       sourceStructuredColumns_ (
-        dynamic_cast<StructuredColumns&> (getSourceFunctionSpace ())),
+        dynamic_cast<StructuredColumns*> (&getSourceFunctionSpace ())),
       targetStructuredColumns_ (
-        dynamic_cast<StructuredColumns&> (getTargetFunctionSpace ())) {
+        dynamic_cast<StructuredColumns*> (&getTargetFunctionSpace ())) {
 
       std::cout << "Constructor on MPI rank " << mpi::rank () << std::endl;
+
+      // Communicate
 
       return;
     }

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #pragma once
 

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
@@ -32,9 +32,18 @@ namespace atlas {
 
     private:
 
+      // Helper struct for function space intersections.
+      struct intersection {
+        idx_t jBegin;
+        idx_t jEnd;
+        std::vector<idx_t> iBegin;
+        std::vector<idx_t> iEnd;
+      };
+
       // FunctionSpaces recast to StructuredColumns.
-      StructuredColumns& sourceStructuredColumns_;
-      StructuredColumns& targetStructuredColumns_;
+      StructuredColumns* sourceStructuredColumns_;
+      StructuredColumns* targetStructuredColumns_;
+
 
     };
   }

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "atlas/repartition/detail/RepartitionImpl.h"
+
+namespace atlas {
+
+  class Field;
+  class FieldSet;
+  class FunctionSpace;
+
+  namespace functionspace {
+    class StructuredColumns;
+  }
+}
+
+namespace atlas {
+  namespace repartition {
+
+    using functionspace::StructuredColumns;
+
+    // Concrete implementation of StructuredColumns to StructuredColumns.
+    class StructuredColumnsToStructuredColumns : public RepartitionImpl {
+
+    public:
+
+      StructuredColumnsToStructuredColumns(
+        const FunctionSpace& sourceFunctionSpace,
+        const FunctionSpace& targetFunctionSpace);
+
+      void execute(const Field &source, Field &target) const override;
+      void execute(const FieldSet &source, FieldSet &target) const override;
+
+    private:
+
+      // FunctionSpaces recast to StructuredColumns.
+      StructuredColumns& sourceStructuredColumns_;
+      StructuredColumns& targetStructuredColumns_;
+
+    };
+  }
+}

--- a/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
+++ b/src/atlas/repartition/detail/StructuredColumnsToStructuredColumns.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <vector>
+
+#include "atlas/functionspace/StructuredColumns.h"
 #include "atlas/repartition/detail/RepartitionImpl.h"
 
 namespace atlas {
@@ -15,6 +18,15 @@ namespace atlas {
 
 namespace atlas {
   namespace repartition {
+
+    using idxPair = std::pair<idx_t, idx_t>;
+    using idxPairVector = std::vector<idxPair>;
+
+    // Helper struct for function space intersections.
+    struct indexRange {
+      idxPair jBeginEnd{};
+      idxPairVector iBeginEnd{};
+    };
 
     using functionspace::StructuredColumns;
 
@@ -32,17 +44,19 @@ namespace atlas {
 
     private:
 
-      // Helper struct for function space intersections.
-      struct intersection {
-        idx_t jBegin;
-        idx_t jEnd;
-        std::vector<idx_t> iBegin;
-        std::vector<idx_t> iEnd;
-      };
-
       // FunctionSpaces recast to StructuredColumns.
-      StructuredColumns* sourceStructuredColumns_;
-      StructuredColumns* targetStructuredColumns_;
+      StructuredColumns sourceStructuredColumns_{};
+      StructuredColumns targetStructuredColumns_{};
+
+      // Function space intersection ranges.
+      std::vector<indexRange> sendIntersections_{};
+      std::vector<indexRange> receiveIntersections_{};
+
+      // MPI count and displacement arrays for send and receive buffers.
+      std::vector<int> sendCounts_{};
+      std::vector<int> sendDisplacements_{};
+      std::vector<int> receiveCounts_{};
+      std::vector<int> receiveDisplacements_{};
 
 
     };

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ add_subdirectory( numerics )
 add_subdirectory( trans )
 add_subdirectory( interpolation )
 add_subdirectory( linalg )
+add_subdirectory( repartition )
 
 add_subdirectory( acceptance_tests )
 add_subdirectory( export_tests )

--- a/src/tests/repartition/CMakeLists.txt
+++ b/src/tests/repartition/CMakeLists.txt
@@ -1,3 +1,9 @@
+#
+# (C) Crown Copyright 2021 Met Office
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
 
 
 ecbuild_add_test( TARGET atlas_test_repartition

--- a/src/tests/repartition/CMakeLists.txt
+++ b/src/tests/repartition/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+
+ecbuild_add_test( TARGET atlas_test_repartition
+  SOURCES   test_repartition.cc
+  LIBS      atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)

--- a/src/tests/repartition/CMakeLists.txt
+++ b/src/tests/repartition/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 ecbuild_add_test( TARGET atlas_test_repartition
   SOURCES   test_repartition.cc
+  MPI       8
   LIBS      atlas
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )

--- a/src/tests/repartition/test_repartition.cc
+++ b/src/tests/repartition/test_repartition.cc
@@ -1,9 +1,10 @@
 /*
- * (C) British Crown Copyright 2021 Met Office
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
+
 
 #include "atlas/field/FieldSet.h"
 #include "atlas/functionspace/StructuredColumns.h"

--- a/src/tests/repartition/test_repartition.cc
+++ b/src/tests/repartition/test_repartition.cc
@@ -1,6 +1,16 @@
+/*
+ * (C) British Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "atlas/field/FieldSet.h"
 #include "atlas/functionspace/StructuredColumns.h"
-#include "atlas/grid/Grid.h"
+#include "atlas/grid.h"
 #include "atlas/grid/Partitioner.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
 #include "atlas/repartition/Repartition.h"
 #include "atlas/util/Config.h"
 
@@ -9,43 +19,261 @@
 namespace atlas {
   namespace test {
 
-    CASE ("hello world") {
-      std::cout << "Hello, world!" << std::endl;
 
-      // Build grids.
-      atlas::util::Config gridOneConfig;
-      gridOneConfig.set("type", "regular_lonlat");
-      gridOneConfig.set("nx", 48);
-      gridOneConfig.set("ny", 37);
+    // Define test pattern for grid.
+    double testPattern(
+      const double lambda, const double phi,
+      const idx_t field, const idx_t level) {
 
-      atlas::Grid gridOne(gridOneConfig);
+      return (1 + field) * std::cos(lambda * (1 + level) * M_PI / 180.)
+        * std::cos(phi * (1 + level) * M_PI / 180.);
+    }
 
-      std::cout << "size " << gridOne.size() << std::endl;
-      std::cout << "name " << gridOne.name() << std::endl;
-
-      // Function spaces.
-      atlas::util::Config funcSpaceOneConfig;
-      funcSpaceOneConfig.set("halo", 1);
-      funcSpaceOneConfig.set("periodic_points", true);
-      funcSpaceOneConfig.set("levels", 1);
-
-      atlas::functionspace::StructuredColumns
-              funcSpaceOne(gridOne, atlas::grid::Partitioner("equal_regions"), funcSpaceOneConfig);
-
-      atlas::functionspace::StructuredColumns
-             funcSpaceTwo(gridOne, atlas::grid::Partitioner("checkerboard"), funcSpaceOneConfig);
-
-      std::cout << "levels" << funcSpaceOne.levels() << std::endl;
-
-      auto fieldOne = funcSpaceOne.createField<double>(atlas::option::name("field one"));
-      auto fieldTwo = funcSpaceTwo.createField<double>(atlas::option::name("field two"));
-
-      auto Repart = atlas::Repartition(funcSpaceOne, funcSpaceTwo);
-
-      Repart.execute(fieldOne, fieldTwo);
+    // Test repartitioner. Return true if test passed.
+    // Output fields if gmshOutput == true.
+    bool testStructColsToStructCols(
+      const atlas::Grid& grid, const idx_t nFields, const idx_t nLevels,
+      const atlas::grid::Partitioner& sourcePartitioner,
+      const atlas::grid::Partitioner& targetPartitioner,
+      const bool gmshOutput = false, const std::string& fileId = "") {
 
 
+      // Set up function spaces.
+      auto funcSpaceConfig = atlas::util::Config{};
+      funcSpaceConfig.set("halo", 1);
+      funcSpaceConfig.set("periodic_points", true);
+      funcSpaceConfig.set("levels", nLevels);
 
+      const auto sourceFunctionSpace = atlas::functionspace::StructuredColumns(
+        grid, sourcePartitioner, funcSpaceConfig);
+
+      const auto targetFunctionSpace = atlas::functionspace::StructuredColumns(
+        grid, targetPartitioner, funcSpaceConfig);
+
+      // Generate some field sets.
+      auto sourceFieldSet = atlas::FieldSet{};
+      for (idx_t field = 0; field < nFields; ++field){
+        sourceFieldSet.add(sourceFunctionSpace.createField<double>(
+          atlas::option::name("source_field_" + std::to_string(field))));
+      }
+
+      auto targetFieldSet = atlas::FieldSet{};
+      for (idx_t field = 0; field < nFields; ++field){
+        targetFieldSet.add(targetFunctionSpace.createField<double>(
+          atlas::option::name("target_field_" + std::to_string(field))));
+      }
+
+      // Write some data to source fields.
+      for (idx_t field = 0; field < sourceFieldSet.size(); ++field) {
+
+        auto fieldView =
+          atlas::array::make_view<double, 2>(sourceFieldSet[field]);
+
+        for (idx_t j = sourceFunctionSpace.j_begin();
+          j < sourceFunctionSpace.j_end(); ++j) {
+
+          for (idx_t i = sourceFunctionSpace.i_begin(j);
+            i < sourceFunctionSpace.i_end(j); ++i) {
+
+            for (idx_t level = 0;
+              level < sourceFunctionSpace.levels(); ++level) {
+
+              // get lon and lat.
+              const auto xy = sourceFunctionSpace.compute_xy(i, j);
+              const auto lonLat = grid.projection().lonlat(xy);
+              const auto lon = lonLat.lon();
+              const auto lat = lonLat.lat();
+              const auto f = testPattern(lon, lat, field, level);
+
+              // write f to field.
+              const auto iNode = sourceFunctionSpace.index(i, j);
+              fieldView(iNode, level) = f;
+
+            }
+          }
+        }
+      }
+
+      // Set up repartitioner.
+      auto repart =
+        atlas::Repartition(sourceFunctionSpace, targetFunctionSpace);
+
+      // Execute repartitioner.
+      repart.execute(sourceFieldSet, targetFieldSet);
+
+      // Read and data from target fields.
+      bool testPassed = true;
+
+      for (idx_t field = 0; field < targetFieldSet.size(); ++field) {
+
+        auto fieldView =
+          atlas::array::make_view<double, 2>(targetFieldSet[field]);
+
+        for (idx_t j = targetFunctionSpace.j_begin();
+          j < targetFunctionSpace.j_end(); ++j) {
+
+          for (idx_t i = targetFunctionSpace.i_begin(j);
+            i < targetFunctionSpace.i_end(j); ++i) {
+
+            for (idx_t level = 0;
+              level < targetFunctionSpace.levels(); ++level) {
+
+              // get lon and lat.
+              const auto xy = targetFunctionSpace.compute_xy(i, j);
+              const auto lonLat = grid.projection().lonlat(xy);
+              const auto lon = lonLat.lon();
+              const auto lat = lonLat.lat();
+              const auto g = testPattern(lon, lat, field, level);
+
+              // read f from field.
+              const auto iNode = targetFunctionSpace.index(i, j);
+              auto f = fieldView(iNode, level);
+
+              // check that f is *exactly* equal to g;
+              testPassed = testPassed && (f == g);
+
+            }
+          }
+        }
+      }
+
+      // Write mesh and fields to file.
+      if (gmshOutput) {
+
+          // Generate meshes.
+          const auto meshGen = atlas::MeshGenerator("structured");
+          const auto sourceMesh = meshGen.generate(grid, sourcePartitioner);
+          const auto targetMesh = meshGen.generate(grid, targetPartitioner);
+
+          // Set gmsh config.
+          auto gmshConfig = atlas::util::Config{};
+          gmshConfig.set("ghost", "true");
+
+          // Write meshes.
+          const auto sourceMeshFile = fileId + "_source_mesh.msh";
+          atlas::output::Gmsh(sourceMeshFile, gmshConfig).write(sourceMesh);
+
+          const auto targetMeshFile = fileId + "_target_mesh.msh";
+          atlas::output::Gmsh(targetMeshFile, gmshConfig).write(targetMesh);
+
+          // Write fields.
+          for (idx_t field = 0; field < sourceFieldSet.size(); ++field) {
+
+            const auto sourceFieldFile =
+              fileId + sourceFieldSet[field].name() + ".msh";
+
+            atlas::output::Gmsh(sourceFieldFile, gmshConfig)
+              .write(sourceFieldSet[field], sourceFunctionSpace);
+
+            const auto targetFieldFile =
+              fileId + targetFieldSet[field].name() + ".msh";
+
+            atlas::output::Gmsh(targetFieldFile, gmshConfig)
+              .write(targetFieldSet[field], targetFunctionSpace);
+
+          }
+      }
+
+      return testPassed;
+    }
+
+    CASE ("StructuredColumns to StructuredColumns") {
+
+
+      SECTION("lonlat: checkerboard to equal_regions") {
+
+        // Set grid.
+        idx_t nFields = 5;
+        idx_t nLevels = 10;
+
+        auto grid = atlas::Grid("L48x37");
+
+        // Set partitioners.
+        auto sourcePartitioner = atlas::grid::Partitioner("checkerboard");
+        auto targetPartitioner = atlas::grid::Partitioner("equal_regions");
+
+        // Check repartitioner.
+        EXPECT(testStructColsToStructCols(grid, nFields, nLevels,
+          sourcePartitioner, targetPartitioner));
+
+        return;
+      }
+
+      SECTION("lonlat: equal_regions to checkerboard") {
+
+        idx_t nFields = 5;
+        idx_t nLevels = 10;
+
+        // Set grid.
+        auto grid = atlas::Grid("L48x37");
+
+        // Set partitioners.
+        auto sourcePartitioner = atlas::grid::Partitioner("equal_regions");
+        auto targetPartitioner = atlas::grid::Partitioner("checkerboard");
+
+        // Check repartitioner.
+        EXPECT(testStructColsToStructCols(grid, nFields, nLevels,
+          sourcePartitioner, targetPartitioner));
+
+        return;
+      }
+
+      SECTION("gaussian: equal_regions to equal_bands") {
+
+        idx_t nFields = 5;
+        idx_t nLevels = 10;
+
+        // Set grid.
+        auto grid = atlas::Grid("O16");
+
+        // Set partitioners.
+        auto sourcePartitioner = atlas::grid::Partitioner("equal_regions");
+        auto targetPartitioner = atlas::grid::Partitioner("equal_bands");
+
+        // Check repartitioner.
+        EXPECT(testStructColsToStructCols(grid, nFields, nLevels,
+          sourcePartitioner, targetPartitioner));
+
+        return;
+      }
+
+      SECTION("gaussian: equal_bands to equal_regions") {
+
+        idx_t nFields = 5;
+        idx_t nLevels = 10;
+
+        // Set grid.
+        auto grid = atlas::Grid("O16");
+
+        // Set partitioners.
+        auto sourcePartitioner = atlas::grid::Partitioner("equal_bands");
+        auto targetPartitioner = atlas::grid::Partitioner("equal_regions");
+
+        // Check repartitioner.
+        EXPECT(testStructColsToStructCols(grid, nFields, nLevels,
+          sourcePartitioner, targetPartitioner));
+
+        return;
+      }
+
+      SECTION("gaussian: gmsh output") {
+
+        idx_t nFields = 1;
+        idx_t nLevels = 5;
+
+        // Set up gaussian grid.
+        auto grid = atlas::Grid("O16");
+
+        // Set partitioners.
+        auto sourcePartitioner = atlas::grid::Partitioner("equal_bands");
+        auto targetPartitioner = atlas::grid::Partitioner("equal_regions");
+
+        // Check repartitioner.
+        EXPECT(testStructColsToStructCols(grid, nFields, nLevels,
+          sourcePartitioner, targetPartitioner, true, grid.name()));
+
+        return;
+      }
 
     }
 

--- a/src/tests/repartition/test_repartition.cc
+++ b/src/tests/repartition/test_repartition.cc
@@ -27,12 +27,15 @@ namespace atlas {
       atlas::util::Config funcSpaceOneConfig;
       funcSpaceOneConfig.set("halo", 1);
       funcSpaceOneConfig.set("periodic_points", true);
+      funcSpaceOneConfig.set("levels", 1);
 
       atlas::functionspace::StructuredColumns
               funcSpaceOne(gridOne, atlas::grid::Partitioner("equal_regions"), funcSpaceOneConfig);
 
       atlas::functionspace::StructuredColumns
              funcSpaceTwo(gridOne, atlas::grid::Partitioner("checkerboard"), funcSpaceOneConfig);
+
+      std::cout << "levels" << funcSpaceOne.levels() << std::endl;
 
       auto fieldOne = funcSpaceOne.createField<double>(atlas::option::name("field one"));
       auto fieldTwo = funcSpaceTwo.createField<double>(atlas::option::name("field two"));

--- a/src/tests/repartition/test_repartition.cc
+++ b/src/tests/repartition/test_repartition.cc
@@ -1,0 +1,18 @@
+
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+  namespace test {
+
+    CASE ("hello world") {
+     std::cout << "Hello, world!" << std::endl;
+    }
+
+  }
+}
+
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}

--- a/src/tests/repartition/test_repartition.cc
+++ b/src/tests/repartition/test_repartition.cc
@@ -1,4 +1,8 @@
-
+#include "atlas/functionspace/StructuredColumns.h"
+#include "atlas/grid/Grid.h"
+#include "atlas/grid/Partitioner.h"
+#include "atlas/repartition/Repartition.h"
+#include "atlas/util/Config.h"
 
 #include "tests/AtlasTestEnvironment.h"
 
@@ -6,7 +10,40 @@ namespace atlas {
   namespace test {
 
     CASE ("hello world") {
-     std::cout << "Hello, world!" << std::endl;
+      std::cout << "Hello, world!" << std::endl;
+
+      // Build grids.
+      atlas::util::Config gridOneConfig;
+      gridOneConfig.set("type", "regular_lonlat");
+      gridOneConfig.set("nx", 48);
+      gridOneConfig.set("ny", 37);
+
+      atlas::Grid gridOne(gridOneConfig);
+
+      std::cout << "size " << gridOne.size() << std::endl;
+      std::cout << "name " << gridOne.name() << std::endl;
+
+      // Function spaces.
+      atlas::util::Config funcSpaceOneConfig;
+      funcSpaceOneConfig.set("halo", 1);
+      funcSpaceOneConfig.set("periodic_points", true);
+
+      atlas::functionspace::StructuredColumns
+              funcSpaceOne(gridOne, atlas::grid::Partitioner("equal_regions"), funcSpaceOneConfig);
+
+      atlas::functionspace::StructuredColumns
+             funcSpaceTwo(gridOne, atlas::grid::Partitioner("checkerboard"), funcSpaceOneConfig);
+
+      auto fieldOne = funcSpaceOne.createField<double>(atlas::option::name("field one"));
+      auto fieldTwo = funcSpaceTwo.createField<double>(atlas::option::name("field two"));
+
+      auto Repart = atlas::Repartition(funcSpaceOne, funcSpaceTwo);
+
+      Repart.execute(fieldOne, fieldTwo);
+
+
+
+
     }
 
   }


### PR DESCRIPTION
## Description

Added functionality to repartition fields  between two StructuredColumns function spaces with the same grid, but different partitioners. All Atlas and um-jedi tests pass in my release build.

### Issue(s) addressed

This allows the rearrangement of field data on Gaussian grids so that it may be processed with Atlas-trans.

- closes issue um-jedi#169

## Dependencies

This is built via the **feature/um_trans** branch of ufo-bundle. It has a few extra dependencies on top of the standard ufo-bunlde dev stack. It you can't build it, get in touch with me.

## Main changes

### Build

Updated from C++11 to C++14.

### atlas/src/atlas/repartition

_Repartition.h; Repartition.cc_
Base class for repartition object.

_detail/RepartitionImpl.h; detail/RepartitionImpl.cc_
Abstract base class for repartition implementation.

_detail/StructuredColumnsToStructuredColumns.h; detail/StructuredColumnsToStructuredColumns.cc_
Concrete implementation for StructuredColumns function spaces.

_detail/RepartitionImplFactory.h; detail/RepartitionImplFactory.cc_
Factory class for RepartitionImpl objects. Currently only one concrete implementation to choose from.

_detail/RepartitionUtils.h_
Utilities for run-time type, size and cast checking.

### atlas/src/tests/repartition

_test_repartition.cc_
Series of tests which run repartitioner on various grid/partitioner combinations. Also output some gmsh mesh and field files to corresponding sub directory in build.


