### PR TITLE
Bugfix/fix compile failures

### DIFF
--- a/src/atlas/redistribution/Redistribution.cc
+++ b/src/atlas/redistribution/Redistribution.cc
@@ -14,6 +14,7 @@
 namespace atlas {
 
 // Use redistribution implementation factory to make object.
+Redistribution::Redistribution(){};
 Redistribution::Redistribution( const FunctionSpace& sourceFunctionSpace, const FunctionSpace& targetFunctionSpace ) :
     Handle( redistribution::detail::RedistributionImplFactory::build( sourceFunctionSpace, targetFunctionSpace ) ) {}
 

--- a/src/atlas/redistribution/Redistribution.cc
+++ b/src/atlas/redistribution/Redistribution.cc
@@ -14,7 +14,7 @@
 namespace atlas {
 
 // Use redistribution implementation factory to make object.
-Redistribution::Redistribution(){};
+Redistribution::Redistribution() : Handle() {};
 Redistribution::Redistribution( const FunctionSpace& sourceFunctionSpace, const FunctionSpace& targetFunctionSpace ) :
     Handle( redistribution::detail::RedistributionImplFactory::build( sourceFunctionSpace, targetFunctionSpace ) ) {}
 

--- a/src/atlas/redistribution/Redistribution.h
+++ b/src/atlas/redistribution/Redistribution.h
@@ -25,7 +25,10 @@ namespace atlas {
 class Redistribution : public util::ObjectHandle<redistribution::detail::RedistributionImpl> {
 public:
     using Handle::Handle;
+
+    /// \brief    Empty default constructor.
     Redistribution();
+
     /// \brief    Constructs and initialises the redistributor.
     ///
     /// \details  Initialises class to copy fields from a source function space

--- a/src/atlas/redistribution/Redistribution.h
+++ b/src/atlas/redistribution/Redistribution.h
@@ -25,7 +25,7 @@ namespace atlas {
 class Redistribution : public util::ObjectHandle<redistribution::detail::RedistributionImpl> {
 public:
     using Handle::Handle;
-
+    Redistribution();
     /// \brief    Constructs and initialises the redistributor.
     ///
     /// \details  Initialises class to copy fields from a source function space


### PR DESCRIPTION
## Description
In order to build um-bundle with different compilers and on different machines, the following changes were made:

- This is adding an empty default constructor for  `class Redistribution`

For more details, see: https://github.com/JCSDA-internal/rosestem_tests_model_interfaces/pull/108 

Here is the error msg that I was getting: 

```
In file included from /spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/functional:55:0,
                 from /spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/memory:79,
                 from /home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/um-jedi/src/um-jedi/ErrorCovariance/ErrorCovariance.cc:9:
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/tuple: In instantiation of ‘std::pair<_T1, _T2>::pair(std::tuple<_Args1 ...>&, std::tuple<_Args2 ...>&, std::_Index_tuple<_Indexes1 ...>, std::_Index_tuple<_Indexes2 ...>) [with _Args1 = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&}; long unsigned int ..._Indexes1 = {0ul}; _Args2 = {}; long unsigned int ..._Indexes2 = {}; _T1 = const std::__cxx11::basic_string<char>; _T2 = atlas::Redistribution]’:
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/tuple:1556:63:   required from ‘std::pair<_T1, _T2>::pair(std::piecewise_construct_t, std::tuple<_Args1 ...>, std::tuple<_Args2 ...>) [with _Args1 = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&}; _Args2 = {}; _T1 = const std::__cxx11::basic_string<char>; _T2 = atlas::Redistribution]’
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/ext/new_allocator.h:120:4:   required from ‘void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution>; _Args = {const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<>}; _Tp = std::_Rb_tree_node<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >]’
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/bits/alloc_traits.h:455:4:   required from ‘static void std::allocator_traits<std::allocator<_Tp1> >::construct(std::allocator_traits<std::allocator<_Tp1> >::allocator_type&, _Up*, _Args&& ...) [with _Up = std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution>; _Args = {const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<>}; _Tp = std::_Rb_tree_node<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; std::allocator_traits<std::allocator<_Tp1> >::allocator_type = std::allocator<std::_Rb_tree_node<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> > >]’
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/bits/stl_tree.h:539:32:   required from ‘void std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_construct_node(std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Link_type, _Args&& ...) [with _Args = {const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<>}; _Key = std::__cxx11::basic_string<char>; _Val = std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution>; _KeyOfValue = std::_Select1st<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Link_type = std::_Rb_tree_node<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >*]’
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/bits/stl_tree.h:556:4:   required from ‘std::_Rb_tree_node<_Val>* std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_create_node(_Args&& ...) [with _Args = {const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<>}; _Key = std::__cxx11::basic_string<char>; _Val = std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution>; _KeyOfValue = std::_Select1st<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Link_type = std::_Rb_tree_node<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >*]’
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/bits/stl_tree.h:2166:64:   required from ‘std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::iterator std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_emplace_hint_unique(std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::const_iterator, _Args&& ...) [with _Args = {const std::piecewise_construct_t&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&>, std::tuple<>}; _Key = std::__cxx11::basic_string<char>; _Val = std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution>; _KeyOfValue = std::_Select1st<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::iterator = std::_Rb_tree_iterator<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::const_iterator = std::_Rb_tree_const_iterator<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >]’
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/bits/stl_map.h:502:8:   required from ‘std::map<_Key, _Tp, _Compare, _Alloc>::mapped_type& std::map<_Key, _Tp, _Compare, _Alloc>::operator[](std::map<_Key, _Tp, _Compare, _Alloc>::key_type&&) [with _Key = std::__cxx11::basic_string<char>; _Tp = atlas::Redistribution; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, atlas::Redistribution> >; std::map<_Key, _Tp, _Compare, _Alloc>::mapped_type = atlas::Redistribution; std::map<_Key, _Tp, _Compare, _Alloc>::key_type = std::__cxx11::basic_string<char>]’
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/um-jedi/src/um-jedi/ErrorCovariance/ErrorCovariance.cc:113:44:   required from here
/spice/data/users/frwd/installs/gcc/gcc-6.1.0-ukmo-v1/gcc-4.8.5/include/c++/6.1.0/tuple:1567:70: error: no matching function for call to ‘atlas::Redistribution::Redistribution()’
         second(std::forward<_Args2>(std::get<_Indexes2>(__tuple2))...)
                                                                      ^
In file included from /home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/um-jedi/src/um-jedi/ErrorCovariance/ErrorCovariance.cc:21:0:
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:27:19: note: candidate: atlas::Redistribution::Redistribution(const atlas::redistribution::detail::RedistributionImpl*)
     using Handle::Handle;
                   ^~~~~~
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:27:19: note:   candidate expects 1 argument, 0 provided
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:37:5: note: candidate: atlas::Redistribution::Redistribution(const atlas::FunctionSpace&, const atlas::FunctionSpace&)
     Redistribution( const FunctionSpace& sourceFunctionSpace, const FunctionSpace& targetFunctionSpace );
     ^~~~~~~~~~~~~~
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:37:5: note:   candidate expects 2 arguments, 0 provided
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:25:7: note: candidate: atlas::Redistribution::Redistribution(const atlas::Redistribution&)
 class Redistribution : public util::ObjectHandle<redistribution::detail::RedistributionImpl> {
       ^~~~~~~~~~~~~~
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:25:7: note:   candidate expects 1 argument, 0 provided
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:25:7: note: candidate: atlas::Redistribution::Redistribution(atlas::Redistribution&&)
/home/h04/kraykova/cylc-run/build_um_2/share/um-bundle/atlas/src/atlas/redistribution/Redistribution.h:25:7: note:   candidate expects 1 argument, 0 provided
make[2]: *** [um-jedi/src/um-jedi/CMakeFiles/unifiedmodel.dir/ErrorCovariance/ErrorCovariance.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [um-jedi/src/um-jedi/CMakeFiles/unifiedmodel.dir/all] Error 2

```
