### PR TITLE
Feature/cubed sphere parallel meshgen

### DIFF
--- a/src/atlas/CMakeLists.txt
+++ b/src/atlas/CMakeLists.txt
@@ -365,10 +365,10 @@ meshgenerator/MeshGenerator.cc
 meshgenerator/MeshGenerator.h
 meshgenerator/detail/CubedSphereMeshGenerator.h
 meshgenerator/detail/CubedSphereMeshGenerator.cc
+meshgenerator/detail/NodalCubedSphereMeshGenerator.h
+meshgenerator/detail/NodalCubedSphereMeshGenerator.cc
 meshgenerator/detail/DelaunayMeshGenerator.h
 meshgenerator/detail/DelaunayMeshGenerator.cc
-meshgenerator/detail/FV3CubedSphereMeshGenerator.h
-meshgenerator/detail/FV3CubedSphereMeshGenerator.cc
 meshgenerator/detail/StructuredMeshGenerator.h
 meshgenerator/detail/StructuredMeshGenerator.cc
 meshgenerator/detail/RegularMeshGenerator.cc

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -55,27 +55,27 @@ void CubedSphereMeshGenerator::configure_defaults() {}
 
 void CubedSphereMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
 
-  // Check for proper grid and need for mesh
+  // Check for correct grid and need for mesh
   ATLAS_ASSERT(!mesh.generated());
   if (!CubedSphereGrid(grid)) {
     throw_Exception("CubedSphereMeshGenerator can only work "
-      "with a cubedsphere grid.", Here());
+    "with a cubedsphere grid.", Here());
   }
 
-  // Check for proper stagger
+  // Check for correct stagger
   const auto gridName = grid.name();
   const auto gridStagger = gridName.substr(gridName.rfind("-") - 1, 1);
 
 
   if (gridStagger != "C") {
     throw_Exception("CubedSphereMeshGenerator can only work with a"
-      "cell-centroid grid. Try FV3CubedSphereMeshGenerator instead.");
+    "cell-centroid grid. Try FV3CubedSphereMeshGenerator instead.");
   }
 
   // Partitioner
   const auto partitioner = grid::Partitioner("checkerboard", 1);
   const auto distribution =
-    grid::Distribution(partitioner.partition(grid));
+  grid::Distribution(partitioner.partition(grid));
 
   generate(grid, distribution, mesh);
 }
@@ -90,7 +90,8 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
   const auto nTiles = csGrid.GetNTiles();
 
   ATLAS_TRACE("CubedSphereMeshGenerator::generate");
-  Log::debug() << "Number of cells per tile edge = " << std::to_string(N) << std::endl;
+  Log::debug() << "Number of cells per tile edge = "
+    << std::to_string(N) << std::endl;
 
   // Set tiles.
   // TODO: this needs to be replaced with regular expression matching.
@@ -129,22 +130,22 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
   auto tji = csGrid.tij().begin();
   for (const auto& xy : csGrid.xy()) {
 
-      // Get local index.
-      const auto cellLocalIdx =
-        cellLocalIdxGrid((*tji).t(), (*tji).j(), (*tji).i());
-      ++tji;
+    // Get local index.
+    const auto cellLocalIdx =
+    cellLocalIdxGrid((*tji).t(), (*tji).j(), (*tji).i());
+    ++tji;
 
-      // Set cell-centroid xy.
-      cellXyArr[static_cast<size_t>(cellLocalIdx)] = xy;
+    // Set cell-centroid xy.
+    cellXyArr[static_cast<size_t>(cellLocalIdx)] = xy;
 
-      // Set remote id to iLocal (all cells owned for now)
-      cellRemoteIdxArr(cellLocalIdx) = cellLocalIdx;
+    // Set remote id to iLocal (all cells owned for now)
+    cellRemoteIdxArr(cellLocalIdx) = cellLocalIdx;
 
-      // Set partition using grid global index.
-      cellPartArr(cellLocalIdx) = 0 ;
+    // Set partition using grid global index.
+    cellPartArr(cellLocalIdx) = 0 ;
 
-      // Set cell global index to grid global index.
-      cellGlobalIdxArr(cellLocalIdx) = gridIdx++;
+    // Set cell global index to grid global index.
+    cellGlobalIdxArr(cellLocalIdx) = gridIdx++;
 
   }
 
@@ -198,7 +199,7 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
 
       // Calculate inverse Jacobian.
       const auto invDet =
-        1./(jacElem.dxByDi * jacElem.dyByDj - jacElem.dxByDj * jacElem.dyByDi);
+      1./(jacElem.dxByDi * jacElem.dyByDj - jacElem.dxByDj * jacElem.dyByDi);
       jacElem.diByDx =  jacElem.dyByDj * invDet;
       jacElem.diByDy = -jacElem.dxByDj * invDet;
       jacElem.djByDx = -jacElem.dyByDi * invDet;
@@ -241,11 +242,11 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
         const auto di = iNode - iCell - 0.5;
         const auto dj = jNode - jCell - 0.5;
         const auto nodeLocalXy = PointXY{
-          x0 + di * xyJacobians[static_cast<size_t>(t)].dxByDi
-             + dj * xyJacobians[static_cast<size_t>(t)].dxByDj,
-          y0 + di * xyJacobians[static_cast<size_t>(t)].dyByDi
-             + dj * xyJacobians[static_cast<size_t>(t)].dyByDj
-        };
+            x0 + di * xyJacobians[static_cast<size_t>(t)].dxByDi
+               + dj * xyJacobians[static_cast<size_t>(t)].dxByDj,
+            y0 + di * xyJacobians[static_cast<size_t>(t)].dyByDi
+               + dj * xyJacobians[static_cast<size_t>(t)].dyByDj
+          };
 
         // Use tile class to convert local xy to remote xy.
         const auto nodeRemoteXy = gridTiles.tileCubePeriodicity(nodeLocalXy, t);
@@ -281,7 +282,7 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
 
           // Set flags.
           mesh::Nodes::Topology::set(nodeFlagsArr(nodeLocalIdx),
-            mesh::Nodes::Topology::GHOST);
+          mesh::Nodes::Topology::GHOST);
           nodeGhostArr(nodeLocalIdx) = 1;
 
           // Set global index (ghost points have unique global index).
@@ -323,10 +324,10 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
 
           // Get nodes of quadrilateral cell.
           const auto quadNodes = std::array<idx_t, 4> {
-            nodeLocalIdxGrid(t, jNode - 1, iNode - 1),
-            nodeLocalIdxGrid(t, jNode - 1, iNode    ),
-            nodeLocalIdxGrid(t, jNode    , iNode    ),
-            nodeLocalIdxGrid(t, jNode    , iNode - 1)
+          nodeLocalIdxGrid(t, jNode - 1, iNode - 1),
+          nodeLocalIdxGrid(t, jNode - 1, iNode    ),
+          nodeLocalIdxGrid(t, jNode    , iNode    ),
+          nodeLocalIdxGrid(t, jNode    , iNode - 1)
           };
 
           // Set node connectivity.
@@ -340,29 +341,29 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
   // Set remote indices of ghost points.
   auto nodeRemoteXyIt = nodeRemoteXyArr.begin();
   for (idx_t nodeLocalIdx = nNodesUnique;
-    nodeLocalIdx < nNodesAll; ++nodeLocalIdx) {
+  nodeLocalIdx < nNodesAll; ++nodeLocalIdx) {
 
-    // Get remote xy
-    const auto nodeRemoteXy = *nodeRemoteXyIt++;
+  // Get remote xy
+  const auto nodeRemoteXy = *nodeRemoteXyIt++;
 
-    // Get remote t
-    const auto t = static_cast<size_t>(
-      gridTiles.tileFromXY(nodeRemoteXy.data()));
+  // Get remote t
+  const auto t = static_cast<size_t>(
+  gridTiles.tileFromXY(nodeRemoteXy.data()));
 
-    // Get remote i and j
-    const auto dx = nodeRemoteXy.x() - xyJacobians[t].xy0.x();
-    const auto dy = nodeRemoteXy.y() - xyJacobians[t].xy0.y();
+  // Get remote i and j
+  const auto dx = nodeRemoteXy.x() - xyJacobians[t].xy0.x();
+  const auto dy = nodeRemoteXy.y() - xyJacobians[t].xy0.y();
 
-    // Round to deal with potential floating point error.
-    const auto i = static_cast<idx_t>(
-      std::round(dx * xyJacobians[t].diByDx + dy * xyJacobians[t].diByDy));
-    const auto j = static_cast<idx_t>(
-      std::round(dx * xyJacobians[t].djByDx + dy * xyJacobians[t].djByDy));
+  // Round to deal with potential floating point error.
+  const auto i = static_cast<idx_t>(
+  std::round(dx * xyJacobians[t].diByDx + dy * xyJacobians[t].diByDy));
+  const auto j = static_cast<idx_t>(
+  std::round(dx * xyJacobians[t].djByDx + dy * xyJacobians[t].djByDy));
 
-    // Set remote index and partition.
-    const auto nodeRemoteIdx = nodeLocalIdxGrid(t, j, i);
-    nodeRemoteIdxArr(nodeLocalIdx) = nodeRemoteIdx;
-    nodePartArr(nodeLocalIdx) = nodePartArr(nodeRemoteIdx);
+  // Set remote index and partition.
+  const auto nodeRemoteIdx = nodeLocalIdxGrid(t, j, i);
+  nodeRemoteIdxArr(nodeLocalIdx) = nodeRemoteIdx;
+  nodePartArr(nodeLocalIdx) = nodePartArr(nodeRemoteIdx);
 
   }
 
@@ -378,15 +379,15 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
 // -------------------------------------------------------------------------------------------------
 
 void CubedSphereMeshGenerator::hash(eckit::Hash& h) const {
-    h.add("CubedSphereMeshGenerator");
-    options.hash(h);
+h.add("CubedSphereMeshGenerator");
+options.hash(h);
 }
 
 // -------------------------------------------------------------------------------------------------
 
 namespace {
 static MeshGeneratorBuilder<CubedSphereMeshGenerator> CubedSphereMeshGenerator(
-        CubedSphereMeshGenerator::static_type());
+CubedSphereMeshGenerator::static_type());
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -247,7 +247,7 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
              + dj * xyJacobians[static_cast<size_t>(t)].dyByDj
         };
 
-        // Use tile class to convert extrapolated xy to true xy.
+        // Use tile class to convert local xy to remote xy.
         const auto nodeRemoteXy = gridTiles.tileCubePeriodicity(nodeLocalXy, t);
 
         // Node is owned if nodeRemoteXy and nodeLocalXy are on same tile.

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -74,7 +74,7 @@ void CubedSphereMeshGenerator::configure_defaults() {
   options.set("part", mpi::rank());
 
   // This options sets the default partitioner.
-  options.set<std::string>("partitioner", "equal_regions");
+  options.set<std::string>("partitioner", "cubed_sphere");
 }
 
 // -----------------------------------------------------------------------------

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc
@@ -73,7 +73,7 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, Mesh& mesh) const {
   }
 
   // Partitioner
-  const auto partitioner = grid::Partitioner("checkerboard", 1);
+  const auto partitioner = grid::Partitioner("equal_regions", util::Config("coordinates", "lonlat"));
   const auto distribution =
   grid::Distribution(partitioner.partition(grid));
 
@@ -89,6 +89,14 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
   const auto N      = csGrid.N();
   const auto nTiles = csGrid.GetNTiles();
 
+  const auto nNodesUnique = nTiles * N * N + 2;
+  const auto nNodesAll    = nTiles * (N + 1) * (N + 1);
+  const auto nCells       = nTiles * N * N;
+
+  // Define bad index values.
+  constexpr auto badIdx = std::numeric_limits<idx_t>::min();
+  constexpr auto badGlobalIdx = std::numeric_limits<gidx_t>::min();
+
   ATLAS_TRACE("CubedSphereMeshGenerator::generate");
   Log::debug() << "Number of cells per tile edge = "
     << std::to_string(N) << std::endl;
@@ -97,73 +105,98 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
   // TODO: this needs to be replaced with regular expression matching.
   auto gridTiles = CubedSphereTiles(util::Config("type", "cubedsphere_lfric"));
 
-  // Number of nodes and cells.
-  const auto nNodesUnique  = nTiles * N * N + 2;
-  const auto nNodesAll     = nTiles * (N + 1) * (N + 1);
-  const auto nCells        = nTiles * N * N;
+  // Get partition information.
+  const auto nParts =   mpi::comm().size();
+  const auto thisPart = mpi::comm().rank();
 
+  // Helper functions to get node and cell idx from (t, j, i).
+  const auto getNodeIdx = [&](idx_t t, idx_t j, idx_t i){
+    // Adjust bounds.
+    t = std::max(std::min(t, nTiles - 1), 0);
+    j = std::max(std::min(j, N), 0);
+    i = std::max(std::min(i, N), 0);
+    return static_cast<size_t>(t * (N + 1) * (N + 1) + j * (N + 1) + i);
+  };
 
-  // Construct mesh cells.
-  auto& cells = mesh.cells();
-  cells.add(new mesh::temporary::Quadrilateral(), nCells);
-  auto cellRemoteIdxArr = array::make_indexview<idx_t, 1>(cells.remote_index());
-  auto cellGlobalIdxArr = array::make_view<gidx_t, 1>(cells.global_index());
-  auto cellPartArr      = array::make_view<int, 1>(cells.partition());
-  auto cellXyArr        = std::vector<PointXY>(static_cast<size_t>(nCells));
+  const auto getCellIdx = [&](idx_t t, idx_t j, idx_t i){
+    // Adjust bounds.
+    t = std::max(std::min(t, nTiles - 1), 0);
+    j = std::max(std::min(j, N - 1), 0);
+    i = std::max(std::min(i, N - 1), 0);
+    return static_cast<size_t>(t * N * N + j * N + i);
+  };
 
-  // Set grid shaped arrays of cell local indices.
-  array::ArrayT<int> cellLocalIdxData(nTiles, N, N);
-  auto cellLocalIdxGrid = array::make_view<idx_t, 3>(cellLocalIdxData);
+  // Define cell record.
+  struct CellRecord {
+    gidx_t  globalIdx{badGlobalIdx};
+    idx_t   remoteIdx{badIdx};
+    idx_t   part{badIdx};
+    PointXY xy{};
+  };
 
-  // Loop over all cells and set local index
-  idx_t cellIdx = 0;
-  for (idx_t t = 0; t < nTiles; ++t) {
-    for (idx_t j = 0; j < N; ++j) {
-      for (idx_t i = 0; i < N; ++i) {
-        cellLocalIdxGrid(t, j, i) = cellIdx++;
-      }
+  // ij bounding box for each face (this partition only).
+  struct BoundingBox {
+    idx_t iBegin{std::numeric_limits<idx_t>::max()};
+    idx_t iEnd{std::numeric_limits<idx_t>::min()};
+    idx_t jBegin{std::numeric_limits<idx_t>::max()};
+    idx_t jEnd{std::numeric_limits<idx_t>::min()};
+  };
+
+  // Make list of all cells.
+  auto globalCells = std::vector<CellRecord>(static_cast<size_t>(nCells));
+
+  // Initialise bounding box.
+  auto cellBounds = std::vector<BoundingBox>(static_cast<size_t>(nTiles));
+
+  // Loop over grid.
+  auto tjiIt = csGrid.tij().begin();
+  auto xyIt = csGrid.xy().begin();
+  auto cellRemoteIdx = std::vector<idx_t>(static_cast<size_t>(nParts));
+  idx_t nCellsLocal = 0;
+
+  std::cout << "Coping grid to cells" << std::endl;
+
+  for (gidx_t gridIdx = 1; gridIdx < csGrid.size() + 1; ++gridIdx) {
+
+    // Get cell index
+    const auto t = (*tjiIt).t();
+    const auto j = (*tjiIt).j();
+    const auto i = (*tjiIt).i();
+    const auto cellIdx = getCellIdx(t, j, i);
+    auto& cell = globalCells[cellIdx];
+
+    // Set global index.
+    cell.globalIdx = gridIdx;
+
+    // Set partition and remote index.
+    cell.part = distribution.partition(gridIdx - 1);
+
+    //cell.part = static_cast<idx_t>(thisPart);
+
+    cell.remoteIdx = cellRemoteIdx[static_cast<size_t>(cell.part)]++;
+
+    // Set xy
+    cell.xy = *xyIt;
+
+    if (cell.part == static_cast<idx_t>(thisPart)) {
+
+      // Keep track of local (t, j, i) bounds.
+      auto& bounds = cellBounds[static_cast<size_t>(t)];
+      bounds.iBegin = std::min(bounds.iBegin, i    );
+      bounds.iEnd   = std::max(bounds.iEnd  , i + 1);
+      bounds.jBegin = std::min(bounds.jBegin, j    );
+      bounds.jEnd   = std::max(bounds.jEnd  , j + 1);
+
+      // Count number of local cells.
+      ++nCellsLocal;
+
     }
+    // Increment iterators.
+    ++tjiIt;
+    ++xyIt;
   }
 
-  // Loop over grid points and set cell global index and xy
-  gidx_t gridIdx = 1;
-  auto tji = csGrid.tij().begin();
-  for (const auto& xy : csGrid.xy()) {
-
-    // Get local index.
-    const auto cellLocalIdx =
-    cellLocalIdxGrid((*tji).t(), (*tji).j(), (*tji).i());
-    ++tji;
-
-    // Set cell-centroid xy.
-    cellXyArr[static_cast<size_t>(cellLocalIdx)] = xy;
-
-    // Set remote id to iLocal (all cells owned for now)
-    cellRemoteIdxArr(cellLocalIdx) = cellLocalIdx;
-
-    // Set partition using grid global index.
-    cellPartArr(cellLocalIdx) = 0 ;
-
-    // Set cell global index to grid global index.
-    cellGlobalIdxArr(cellLocalIdx) = gridIdx++;
-
-  }
-
-  // Construct mesh nodes.
-  auto& nodes = mesh.nodes();
-  nodes.resize(nNodesAll);
-  auto nodeRemoteIdxArr = array::make_view<idx_t, 1>(nodes.remote_index());
-  auto nodeGlobalIdxArr = array::make_view<gidx_t, 1>(nodes.global_index());
-  auto nodePartArr      = array::make_view<int, 1>(nodes.partition());
-  auto nodeLocalXyArr   = array::make_view<double, 2>(nodes.xy());
-  auto nodeLonLatArr    = array::make_view<double, 2>(nodes.lonlat());
-  auto nodeGhostArr     = array::make_view<int, 1>(nodes.ghost());
-  auto nodeFlagsArr     = array::make_view<int, 1>(nodes.flags());
-  auto nodeRemoteXyArr  = std::vector<PointXY>{};
-
-  // Set grid shaped array of node local indices.
-  array::ArrayT<int> nodeLocalIdxData(nTiles, N + 1, N + 1);
-  auto nodeLocalIdxGrid = array::make_view<idx_t, 3>(nodeLocalIdxData);
+  std::cout << "Setting jacobian" << std::endl;
 
   // Calculate Jacobian of xy wrt ij for each tile so that we can easily
   // switch between the two.
@@ -176,7 +209,7 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
     double diByDy{};
     double djByDx{};
     double djByDy{};
-    PointXY xy0{};
+    PointXY xy00{};
   };
 
   idx_t t = 0;
@@ -186,29 +219,29 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
       // Initialise element.
       auto jacElem = Jacobian{};
 
-      // Get cell indices.
-      const auto ij00 = static_cast<size_t>(cellLocalIdxGrid(t, 0, 0));
-      const auto ij10 = static_cast<size_t>(cellLocalIdxGrid(t, 0, 1));
-      const auto ij01 = static_cast<size_t>(cellLocalIdxGrid(t, 1, 0));
+      // Get cell positions.
+      const auto& xy00 = globalCells[getCellIdx(t, 0, 0)].xy;
+      const auto& xy10 = globalCells[getCellIdx(t, 0, 1)].xy;
+      const auto& xy01 = globalCells[getCellIdx(t, 1, 0)].xy;
 
       // Calculate Jacobian.
-      jacElem.dxByDi = cellXyArr[ij10].x() - cellXyArr[ij00].x();
-      jacElem.dxByDj = cellXyArr[ij01].x() - cellXyArr[ij00].x();
-      jacElem.dyByDi = cellXyArr[ij10].y() - cellXyArr[ij00].y();
-      jacElem.dyByDj = cellXyArr[ij01].y() - cellXyArr[ij00].y();
+      jacElem.dxByDi = xy10.x() - xy00.x();
+      jacElem.dxByDj = xy01.x() - xy00.x();
+      jacElem.dyByDi = xy10.y() - xy00.y();
+      jacElem.dyByDj = xy01.y() - xy00.y();
 
       // Calculate inverse Jacobian.
       const auto invDet =
-      1./(jacElem.dxByDi * jacElem.dyByDj - jacElem.dxByDj * jacElem.dyByDi);
+        1./(jacElem.dxByDi * jacElem.dyByDj - jacElem.dxByDj * jacElem.dyByDi);
       jacElem.diByDx =  jacElem.dyByDj * invDet;
       jacElem.diByDy = -jacElem.dxByDj * invDet;
       jacElem.djByDx = -jacElem.dyByDi * invDet;
       jacElem.djByDy =  jacElem.dxByDi * invDet;
 
-      // Extrapolate to get xy of node(t, 0, 0)
-      jacElem.xy0 = PointXY{
-        cellXyArr[ij00].x() - 0.5 * jacElem.dxByDi - 0.5 * jacElem.dxByDj,
-        cellXyArr[ij00].y() - 0.5 * jacElem.dyByDi - 0.5 * jacElem.dyByDj
+      // Extrapolate cell(t, 0, 0) xy to get node(t, 0, 0) xy.
+      jacElem.xy00 = PointXY{
+        xy00.x() - 0.5 * jacElem.dxByDi - 0.5 * jacElem.dxByDj,
+        xy00.y() - 0.5 * jacElem.dyByDi - 0.5 * jacElem.dyByDj
       };
 
       ++t;
@@ -216,162 +249,310 @@ void CubedSphereMeshGenerator::generate(const Grid& grid, const grid::Distributi
 
     });
 
-  // Initialise node connectivity.
-  auto& nodeConnectivity = mesh.cells().node_connectivity();
+  // Define node record.
+  struct NodeRecord {
+    gidx_t  globalIdx{badGlobalIdx};
+    idx_t   remoteIdx{badIdx};
+    idx_t   localIdx{badIdx};
+    idx_t   remotePart{badIdx};
+    idx_t   localPart{badIdx};
+    idx_t   t{badIdx};
+    PointXY localXy{};
+    PointXY remoteXy{};
+  };
 
-  // Loop over cells and add nodes.
-  idx_t nodeLocalOwnedIdx = 0;
-  idx_t nodeLocalGhostIdx = nNodesUnique;
+
+  std::cout << "Building global nodes" << std::endl;
+
+  auto globalNodes = std::vector<NodeRecord>(static_cast<size_t>(nNodesAll));
+
+  // Loop over *all* nodes.
+  auto nNodesOwned = std::vector<idx_t>(nParts);
   gidx_t nodeGlobalOwnedIdx = 1;
   gidx_t nodeGlobalGhostIdx = nNodesUnique + 1;
 
+  auto edgeGhostNodes = std::vector<NodeRecord*>{};
+
   for (idx_t t = 0; t < nTiles; ++t) {
     for (idx_t jNode = 0; jNode < N + 1; ++jNode) {
-      for (idx_t iNode = 0; iNode < N + 1 ; ++iNode) {
+      for (idx_t iNode = 0; iNode < N + 1; ++iNode) {
 
-        // Get cell indices.
-        const auto iCell = std::max(0, iNode - 1);
-        const auto jCell = std::max(0, jNode - 1);
-        const auto cellLocalIdx = cellLocalIdxGrid(t, jCell, iCell);
+        // Set and get node.
+        auto& node = globalNodes[getNodeIdx(t, jNode, iNode)];
 
-        // Get cell centre.
-        const auto x0 = cellXyArr[static_cast<size_t>(cellLocalIdx)].x();
-        const auto y0 = cellXyArr[static_cast<size_t>(cellLocalIdx)].y();
+        // Get owning cell.
+        const auto iCell = std::max(iNode - 1, 0);
+        const auto jCell = std::max(jNode - 1, 0);
+        const auto& cell = globalCells[getCellIdx(t, jCell, iCell)];
 
-        // Extrapolate node xy from cell centre.
+        // Extrapolate local xy from cell centre.
         const auto di = iNode - iCell - 0.5;
         const auto dj = jNode - jCell - 0.5;
-        const auto nodeLocalXy = PointXY{
-            x0 + di * xyJacobians[static_cast<size_t>(t)].dxByDi
-               + dj * xyJacobians[static_cast<size_t>(t)].dxByDj,
-            y0 + di * xyJacobians[static_cast<size_t>(t)].dyByDi
-               + dj * xyJacobians[static_cast<size_t>(t)].dyByDj
+        const auto& jac = xyJacobians[static_cast<size_t>(t)];
+        node.localXy = PointXY{
+            cell.xy.x() + di * jac.dxByDi + dj * jac.dxByDj,
+            cell.xy.y() + di * jac.dyByDi + dj * jac.dyByDj
           };
 
-        // Use tile class to convert local xy to remote xy.
-        const auto nodeRemoteXy = gridTiles.tileCubePeriodicity(nodeLocalXy, t);
+        // Get remote xy from tile class and "implied" t.
+        node.remoteXy = gridTiles.tileCubePeriodicity(node.localXy, t);
 
-        // Node is owned if nodeRemoteXy and nodeLocalXy are on same tile.
-        idx_t nodeLocalIdx{};
-        if (gridTiles.tileFromXY(nodeRemoteXy.data()) == t) {
+        // Local part always taken from owning cell.
+        node.localPart = cell.part;
 
-          // Owned node.
+        // Get actual t from tile class.
+        node.t = gridTiles.tileFromXY(node.remoteXy.data());
 
-          // Get local node index.
-          nodeLocalIdx = nodeLocalOwnedIdx++;
+        // Node is an edge ghost point if actual and implied t differ.
+        if (t == node.t) {
 
-          // Set flags
-          mesh::Nodes::Topology::reset(nodeFlagsArr(nodeLocalIdx));
-          nodeGhostArr(nodeLocalIdx) = 0;
+          // Non edge ghost.
 
-          // Set global index
-          nodeGlobalIdxArr(nodeLocalIdx) = nodeGlobalOwnedIdx++;
+          // Set global index.
+          node.globalIdx = nodeGlobalOwnedIdx++;
 
-          // Set remote id to local index (all node owned for now).
-          nodeRemoteIdxArr(nodeLocalIdx) = nodeLocalIdx;
-
-          // Set partition to cell part
-          nodePartArr(nodeLocalIdx) = cellPartArr(cellLocalIdx);
+          // Set parition and remote index.
+          node.remotePart = node.localPart;
+          node.remoteIdx = nNodesOwned[static_cast<size_t>(node.remotePart)]++;
 
         } else {
 
-          // Ghost node.
+          // Edge ghost.
 
-          // Get local node index.
-          nodeLocalIdx = nodeLocalGhostIdx++;
 
-          // Set flags.
-          mesh::Nodes::Topology::set(nodeFlagsArr(nodeLocalIdx),
-          mesh::Nodes::Topology::GHOST);
-          nodeGhostArr(nodeLocalIdx) = 1;
+          // Set global index
+          node.globalIdx = nodeGlobalGhostIdx++;
 
-          // Set global index (ghost points have unique global index).
-          nodeGlobalIdxArr(nodeLocalIdx) = nodeGlobalGhostIdx++;
 
-          // Need to work this out once we've populated rest of mesh.
-          nodeRemoteIdxArr(nodeLocalIdx) = -1;
-
-          // Need to work this out once we've populated rest of mesh.
-          nodePartArr(nodeLocalIdx) = -1;
-
-          // Keep track of remote xy.
-          nodeRemoteXyArr.push_back(nodeRemoteXy);
+          //Add to list and sort later.
+          edgeGhostNodes.push_back(&node);
 
         }
-
-        // Set xy
-        nodeLocalXyArr(nodeLocalIdx, XX) = nodeLocalXy.x();
-        nodeLocalXyArr(nodeLocalIdx, YY) = nodeLocalXy.y();
-
-        // Set node lon and lat.
-        const PointLonLat lonLat = csGrid.projection().lonlat(nodeRemoteXy);
-        nodeLonLatArr(nodeLocalIdx, LON) = lonLat.lon();
-        nodeLonLatArr(nodeLocalIdx, LAT) = lonLat.lat();
-
-        // Update local node grid.
-        nodeLocalIdxGrid(t, jNode, iNode) = nodeLocalIdx;
-
-        // Node layout relative to cell.
-        //
-        //  ^  N3 - N2
-        //  ^  |  C  |
-        //  j  N0 - N1
-        //      i > >
-        //
-        // C: Cell
-        // N0, N1, N2, N3: Nodes
-        if (iNode > 0 && jNode > 0) {
-
-          // Get nodes of quadrilateral cell.
-          const auto quadNodes = std::array<idx_t, 4> {
-          nodeLocalIdxGrid(t, jNode - 1, iNode - 1),
-          nodeLocalIdxGrid(t, jNode - 1, iNode    ),
-          nodeLocalIdxGrid(t, jNode    , iNode    ),
-          nodeLocalIdxGrid(t, jNode    , iNode - 1)
-          };
-
-          // Set node connectivity.
-          nodeConnectivity.set(cellLocalIdx, quadNodes.data());
-        }
-
       }
     }
   }
 
-  // Set remote indices of ghost points.
-  auto nodeRemoteXyIt = nodeRemoteXyArr.begin();
-  for (idx_t nodeLocalIdx = nNodesUnique;
-  nodeLocalIdx < nNodesAll; ++nodeLocalIdx) {
+  std::cout << "sort edge-ghosts" << std::endl;
 
-  // Get remote xy
-  const auto nodeRemoteXy = *nodeRemoteXyIt++;
+  // Sort out edge-ghost nodes.
+  for (auto nodePtr : edgeGhostNodes) {
 
-  // Get remote t
-  const auto t = static_cast<size_t>(
-  gridTiles.tileFromXY(nodeRemoteXy.data()));
+    // Get jacobian.
+    std::cout << "t " << nodePtr->t << std::endl;
+    const auto& jac = xyJacobians[static_cast<size_t>(nodePtr->t)];
 
-  // Get remote i and j
-  const auto dx = nodeRemoteXy.x() - xyJacobians[t].xy0.x();
-  const auto dy = nodeRemoteXy.y() - xyJacobians[t].xy0.y();
+    // Get actual i and j.
+    const auto dx = nodePtr->remoteXy.x() - jac.xy00.x();
+    const auto dy = nodePtr->remoteXy.y() - jac.xy00.y();
+    const auto i = static_cast<idx_t>(
+      std::round(dx * jac.diByDx + dy * jac.diByDy));
+    const auto j = static_cast<idx_t>(
+      std::round(dx * jac.djByDx + dy * jac.djByDy));
 
-  // Round to deal with potential floating point error.
-  const auto i = static_cast<idx_t>(
-  std::round(dx * xyJacobians[t].diByDx + dy * xyJacobians[t].diByDy));
-  const auto j = static_cast<idx_t>(
-  std::round(dx * xyJacobians[t].djByDx + dy * xyJacobians[t].djByDy));
+    // Get remote node.
 
-  // Set remote index and partition.
-  const auto nodeRemoteIdx = nodeLocalIdxGrid(t, j, i);
-  nodeRemoteIdxArr(nodeLocalIdx) = nodeRemoteIdx;
-  nodePartArr(nodeLocalIdx) = nodePartArr(nodeRemoteIdx);
+    std::cout << t << " " << j << " " << i << std::endl;
+    const auto& remoteNode = globalNodes[getNodeIdx(nodePtr->t, j, i)];
+
+    // Set partition and remote index.
+    nodePtr->remotePart = remoteNode.localPart;
+    nodePtr->remoteIdx = remoteNode.globalIdx - 1;
 
   }
 
-  nodes.metadata().set( "parallel", true );
 
-  // check that node counts are correct
-  ATLAS_ASSERT(nodeLocalOwnedIdx = nNodesUnique);
-  ATLAS_ASSERT(nodeLocalGhostIdx = nNodesAll);
+
+  // Make list of local owned and ghost nodes.
+  auto localNodesOwned = std::vector<const NodeRecord*>{};
+  auto localNodesGhost = std::vector<const NodeRecord*>{};
+
+  // Loop over *local* nodes.
+  idx_t localNodeOwnedIdx = 0;
+  idx_t localNodeGhostIdx = nNodesOwned[thisPart];
+
+
+  std::cout << "Selecting local nodes" << std::endl;
+
+  for (idx_t t = 0; t < nTiles; ++t) {
+
+    const auto bounds = cellBounds[static_cast<size_t>(t)];
+
+    for (idx_t jNode = 0; jNode < N + 1; ++jNode) {
+      for (idx_t iNode = 0; iNode < N + 1; ++iNode) {
+
+        // Get node.
+        const auto nodeIdx = getNodeIdx(t, jNode, iNode);
+        auto& node = globalNodes[nodeIdx];
+
+        // Check if node is owned or edge ghost point.
+        if (node.localPart == static_cast<idx_t>(thisPart)) {
+
+          if (node.t == t) {
+
+            // Node is owned.
+
+            // Set local index.
+            node.localIdx = localNodeOwnedIdx++;
+
+            std::cout << node.remoteIdx << " " << node.localIdx << std::endl;
+
+            // Add node to list.
+            localNodesOwned.push_back(&node);
+
+          } else {
+
+            // Node is an edge ghost point.
+
+            // Set local index.
+            node.localIdx = localNodeGhostIdx++;
+
+            node.remoteIdx = node.globalIdx - 1;
+
+
+            // Add node to list.
+            localNodesGhost.push_back(&node);
+
+          }
+        } else {
+
+          // Might be a ghost point. Need to check non-owning surrounding cells.
+          const auto& cell1 = globalCells[getCellIdx(t, jNode    , iNode - 1)];
+          const auto& cell2 = globalCells[getCellIdx(t, jNode    , iNode    )];
+          const auto& cell3 = globalCells[getCellIdx(t, jNode - 1, iNode    )];
+
+          if ( cell1.part == static_cast<idx_t>(thisPart) ||
+               cell2.part == static_cast<idx_t>(thisPart) ||
+               cell3.part == static_cast<idx_t>(thisPart)) {
+
+            // Set local index.
+            node.localIdx = localNodeGhostIdx++;
+
+            // Add node to list.
+            localNodesGhost.push_back(&node);
+
+          }
+        }
+      }
+    }
+  }
+
+  std::cout << "writing to nodes to mesh." << std::endl;
+
+  // We now have enough information to construct mesh.
+  const auto nNodesLocalOwned = static_cast<idx_t>(localNodesOwned.size());
+  const auto nNodesLocalGhost = static_cast<idx_t>(localNodesGhost.size());
+  const auto nNodesLocalAll = nNodesLocalOwned + nNodesLocalGhost;
+
+  // Resize nodes.
+  mesh.nodes().resize(nNodesLocalAll);
+
+  // Get field views
+  auto meshNodesXy        = array::make_view<double, 2>(mesh.nodes().xy());
+  auto meshNodesLonLat    = array::make_view<double, 2>(mesh.nodes().lonlat());
+  auto meshNodesGobalIdx  = array::make_view<gidx_t, 1>(mesh.nodes().global_index());
+  auto meshNodesRemoteIdx = array::make_indexview<idx_t, 1>(mesh.nodes().remote_index());
+  auto meshNodesPart      = array::make_view<int, 1>(mesh.nodes().partition());
+  auto meshNodesGhost     = array::make_view<int, 1>(mesh.nodes().ghost());
+  auto meshNodesFlags     = array::make_view<int, 1>(mesh.nodes().flags());
+
+  // Set owned nodes.
+  auto nodeOwnedIt = localNodesOwned.begin();
+  auto nodeGhostIt = localNodesGhost.begin();
+  for (idx_t nodeIdx = 0; nodeIdx < nNodesLocalAll; ++nodeIdx) {
+
+    // Get node record.
+    const auto ghost = nodeIdx >= nNodesLocalOwned;
+    const auto& node = ghost ? **nodeGhostIt++ : **nodeOwnedIt++;
+
+    // Set xy.
+    meshNodesXy(nodeIdx, XX) = node.localXy.x();
+    meshNodesXy(nodeIdx, YY) = node.localXy.y();
+
+    // Set lon-lat.
+    const auto lonLat = csGrid.projection().lonlat(node.remoteXy);
+    meshNodesLonLat(nodeIdx, LON) = lonLat.lon();
+    meshNodesLonLat(nodeIdx, LAT) = lonLat.lat();
+
+    // Set global index.
+    meshNodesGobalIdx(nodeIdx) = node.globalIdx;
+
+    // Set remote index
+    meshNodesRemoteIdx(nodeIdx) = node.remoteIdx;
+    if (!ghost) meshNodesRemoteIdx(nodeIdx) = - 1;
+
+
+    // Set partition.
+    meshNodesPart(nodeIdx) = node.remotePart;
+
+    // Set ghost flag.
+    meshNodesGhost(nodeIdx) = ghost;
+
+    mesh::Nodes::Topology::reset(meshNodesFlags(nodeIdx));
+    if (ghost) mesh::Nodes::Topology::set(meshNodesFlags(nodeIdx), mesh::Nodes::Topology::GHOST);
+  }
+
+  std::cout << "writing to cells to mesh. " << nCellsLocal << std::endl;
+
+  // Resize cells.
+  mesh.cells().add(new mesh::temporary::Quadrilateral(), nCellsLocal);
+
+  // Set field views.
+  auto meshCellsRemoteIdx = array::make_indexview<idx_t, 1>(mesh.cells().remote_index());
+  auto meshCellsGlobalIdx = array::make_view<gidx_t, 1>(mesh.cells().global_index());
+  auto meshCellsPart      = array::make_view<int, 1>(mesh.cells().partition());
+
+  // Set local cells.
+  auto& nodeConnectivity = mesh.cells().node_connectivity();
+  idx_t cellIdx = 0;
+
+  for (idx_t t = 0; t < nTiles; ++t) {
+
+    const auto bounds = cellBounds[static_cast<size_t>(t)];
+
+    for (idx_t jCell = 0; jCell < N; ++jCell) {
+      for (idx_t iCell = 0; iCell < N; ++iCell) {
+
+        // Get cell.
+        const auto& cell = globalCells[getCellIdx(t, jCell, iCell)];
+
+        // Only add cells on this partition.
+        if (cell.part == static_cast<idx_t>(thisPart)) {
+
+          // Set global index.
+          meshCellsGlobalIdx(cellIdx) = cell.globalIdx;
+
+          // Set remote index.
+          meshCellsRemoteIdx(cellIdx) = cell.remoteIdx;
+
+          // Set partition.
+          meshCellsPart(cellIdx) = cell.part;
+
+          // Set quadrilateral.
+          const auto i0 = globalNodes[getNodeIdx(t, jCell    , iCell    )].localIdx;
+          const auto i1 = globalNodes[getNodeIdx(t, jCell    , iCell + 1)].localIdx;
+          const auto i2 = globalNodes[getNodeIdx(t, jCell + 1, iCell + 1)].localIdx;
+          const auto i3 = globalNodes[getNodeIdx(t, jCell + 1, iCell    )].localIdx;
+          const auto quadNodeIdx = std::array<idx_t, 4> {i0, i1, i2, i3};
+
+
+          std::cout << quadNodeIdx << std::endl;
+
+          // Set connectivity.
+          nodeConnectivity.set(cellIdx, quadNodeIdx.data());
+
+          // Incriment cell index.
+          ++cellIdx;
+
+        }
+      }
+    }
+  }
+
+  //generateGlobalElementNumbering( mesh );
+  mesh.nodes().metadata().set( "periodic", true );
+  mesh.nodes().metadata().set( "parallel", true );
+
+  std::cout << "mesh generated " << cellIdx << " " <<nCellsLocal <<std::endl;
 
   return;
 }

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.h
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020 UCAR
+ * (C) Crown Copyright 2021 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.h
+++ b/src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.h
@@ -19,6 +19,7 @@ class Parametrisation;
 }
 
 namespace atlas {
+class CubedSphereGrid;
 class Mesh;
 template <typename T>
 class vector;
@@ -53,6 +54,8 @@ private:
   virtual void hash( eckit::Hash& ) const override;
 
   void configure_defaults();
+
+  void generate_mesh( const CubedSphereGrid&, const grid::Distribution&, Mesh& ) const;
 
 private:
   util::Metadata options;

--- a/src/atlas/meshgenerator/detail/MeshGeneratorFactory.cc
+++ b/src/atlas/meshgenerator/detail/MeshGeneratorFactory.cc
@@ -14,6 +14,7 @@
 #include "atlas/meshgenerator/detail/DelaunayMeshGenerator.h"
 #include "atlas/meshgenerator/detail/HealpixMeshGenerator.h"
 #include "atlas/meshgenerator/detail/MeshGeneratorFactory.h"
+#include "atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.h"
 #include "atlas/meshgenerator/detail/StructuredMeshGenerator.h"
 
 using atlas::Mesh;
@@ -30,6 +31,7 @@ void force_link() {
             MeshGeneratorBuilder<meshgenerator::StructuredMeshGenerator>();
             MeshGeneratorBuilder<meshgenerator::DelaunayMeshGenerator>();
             MeshGeneratorBuilder<meshgenerator::HealpixMeshGenerator>();
+            MeshGeneratorBuilder<meshgenerator::NodalCubedSphereMeshGenerator>();
         }
     } link;
 }

--- a/src/atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.cc
@@ -24,8 +24,8 @@
 #include "atlas/mesh/HybridElements.h"
 #include "atlas/mesh/Mesh.h"
 #include "atlas/mesh/Nodes.h"
-#include "atlas/meshgenerator/detail/FV3CubedSphereMeshGenerator.h"
 #include "atlas/meshgenerator/detail/MeshGeneratorFactory.h"
+#include "atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/Exception.h"
 #include "atlas/runtime/Log.h"
@@ -42,20 +42,20 @@ namespace meshgenerator {
 
 // -------------------------------------------------------------------------------------------------
 
-FV3CubedSphereMeshGenerator::FV3CubedSphereMeshGenerator( const eckit::Parametrisation& p ) {}
+NodalCubedSphereMeshGenerator::NodalCubedSphereMeshGenerator( const eckit::Parametrisation& p ) {}
 
 // -------------------------------------------------------------------------------------------------
 
-void FV3CubedSphereMeshGenerator::configure_defaults() {}
+void NodalCubedSphereMeshGenerator::configure_defaults() {}
 
 // -------------------------------------------------------------------------------------------------
 
-void FV3CubedSphereMeshGenerator::generate( const Grid& grid, Mesh& mesh ) const {
+void NodalCubedSphereMeshGenerator::generate( const Grid& grid, Mesh& mesh ) const {
     // Check for proper grid and need for mesh
     ATLAS_ASSERT( !mesh.generated() );
     const CubedSphereGrid csg = CubedSphereGrid( grid );
     if ( !csg ) {
-        throw_Exception( "FV3CubedSphereMeshGenerator can only work with a cubedsphere grid", Here() );
+        throw_Exception( "NodalCubedSphereMeshGenerator can only work with a cubedsphere grid", Here() );
     }
 
     // Number of processors
@@ -74,7 +74,7 @@ void FV3CubedSphereMeshGenerator::generate( const Grid& grid, Mesh& mesh ) const
 
 // -------------------------------------------------------------------------------------------------
 
-void FV3CubedSphereMeshGenerator::generate( const Grid& grid, const grid::Distribution& distribution, Mesh& mesh ) const {
+void NodalCubedSphereMeshGenerator::generate( const Grid& grid, const grid::Distribution& distribution, Mesh& mesh ) const {
     const auto csgrid = CubedSphereGrid( grid );
 
     const int N      = csgrid.N();
@@ -138,7 +138,7 @@ void FV3CubedSphereMeshGenerator::generate( const Grid& grid, const grid::Distri
     // END FV3 SPECIFIC MAP
     // -------------------------------------------------------------------------
 
-    ATLAS_TRACE( "FV3CubedSphereMeshGenerator::generate" );
+    ATLAS_TRACE( "NodalCubedSphereMeshGenerator::generate" );
     Log::debug() << "Number of faces per tile edge = " << std::to_string( N ) << std::endl;
 
     // Number of nodes
@@ -324,16 +324,16 @@ void FV3CubedSphereMeshGenerator::generate( const Grid& grid, const grid::Distri
 
 // -------------------------------------------------------------------------------------------------
 
-void FV3CubedSphereMeshGenerator::hash( eckit::Hash& h ) const {
-    h.add( "FV3CubedSphereMeshGenerator" );
+void NodalCubedSphereMeshGenerator::hash( eckit::Hash& h ) const {
+    h.add( "NodalCubedSphereMeshGenerator" );
     options.hash( h );
 }
 
 // -------------------------------------------------------------------------------------------------
 
 namespace {
-static MeshGeneratorBuilder<FV3CubedSphereMeshGenerator> FV3CubedSphereMeshGenerator(
-        FV3CubedSphereMeshGenerator::static_type() );
+static MeshGeneratorBuilder<NodalCubedSphereMeshGenerator> NodalCubedSphereMeshGenerator(
+        NodalCubedSphereMeshGenerator::static_type() );
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.h
+++ b/src/atlas/meshgenerator/detail/NodalCubedSphereMeshGenerator.h
@@ -36,16 +36,16 @@ namespace meshgenerator {
 
 //--------------------------------------------------------------------------------------------------
 
-class FV3CubedSphereMeshGenerator : public MeshGenerator::Implementation {
+class NodalCubedSphereMeshGenerator : public MeshGenerator::Implementation {
 public:
-    FV3CubedSphereMeshGenerator( const eckit::Parametrisation& = util::NoConfig() );
+    NodalCubedSphereMeshGenerator( const eckit::Parametrisation& = util::NoConfig() );
 
     virtual void generate( const Grid&, const grid::Distribution&, Mesh& ) const override;
     virtual void generate( const Grid&, Mesh& ) const override;
 
     using MeshGenerator::Implementation::generate;
 
-    static std::string static_type() { return "FV3-cubedsphere"; }
+    static std::string static_type() { return "nodal-cubedsphere"; }
     std::string type() const override { return static_type(); }
 
 private:

--- a/src/tests/grid/test_cubedsphere.cc
+++ b/src/tests/grid/test_cubedsphere.cc
@@ -101,7 +101,7 @@ namespace atlas {
       // I expect this will be replaced by some more aggressive tests.
 
       // Set grid.
-      const auto grid = atlas::Grid("CS-LFR-C-12");
+      const auto grid = atlas::Grid("CS-LFR-C-32");
 
       atlas::Log::info() << grid.name() << std::endl;
       atlas::Log::info() << grid.size() << std::endl;
@@ -133,6 +133,10 @@ namespace atlas {
       auto gmshConfigXy = atlas::util::Config("coordinates", "xy");
       auto gmshConfigXyz = atlas::util::Config("coordinates", "xyz");
       auto gmshConfigLonLat = atlas::util::Config("coordinates", "lonlat");
+
+      gmshConfigXy.set("ghost", "true");
+      gmshConfigXyz.set("ghost", "true");
+      gmshConfigLonLat.set("ghost", "true");
 
       // Set source gmsh object.
       const auto gmshXy =

--- a/src/tests/grid/test_cubedsphere.cc
+++ b/src/tests/grid/test_cubedsphere.cc
@@ -109,7 +109,7 @@ namespace atlas {
 
       // Set mesh.
       auto meshGen = atlas::MeshGenerator("cubedsphere");
-      const auto mesh = meshGen.generate(grid);
+      auto mesh = meshGen.generate(grid);
 
       // Set functionspace
       auto functionSpace = atlas::functionspace::NodeColumns(mesh);

--- a/src/tests/grid/test_cubedsphere.cc
+++ b/src/tests/grid/test_cubedsphere.cc
@@ -83,7 +83,7 @@ namespace atlas {
 
 
       // Set mesh.
-      auto meshGen = atlas::MeshGenerator("FV3-cubedsphere");
+      auto meshGen = atlas::MeshGenerator("nodal-cubedsphere");
       auto mesh = meshGen.generate(grid);
 
       // Set functionspace
@@ -108,18 +108,18 @@ namespace atlas {
       // Set source gmsh object.
       const auto gmshXy =
         atlas::output::Gmsh("FV3_xy_mesh.msh", gmshConfigXy);
-      //const auto gmshXyz =
-        //atlas::output::Gmsh("FV3_xyz_mesh.msh", gmshConfigXyz);
-      //const auto gmshLonLat =
-        //atlas::output::Gmsh("FV3_lonlat_mesh.msh", gmshConfigLonLat);
+      const auto gmshXyz =
+        atlas::output::Gmsh("FV3_xyz_mesh.msh", gmshConfigXyz);
+      const auto gmshLonLat =
+        atlas::output::Gmsh("FV3_lonlat_mesh.msh", gmshConfigLonLat);
 
       // Write gmsh.
-      //gmshXy.write(mesh);
-      //gmshXy.write(field);
-      //gmshXyz.write(mesh);
-      //gmshXyz.write(field);
-      //gmshLonLat.write(mesh);
-      //gmshLonLat.write(field);
+      gmshXy.write(mesh);
+      gmshXy.write(field);
+      gmshXyz.write(mesh);
+      gmshXyz.write(field);
+      gmshLonLat.write(mesh);
+      gmshLonLat.write(field);
 
 
     }
@@ -140,19 +140,6 @@ namespace atlas {
       auto meshGen = atlas::MeshGenerator("cubedsphere");
       auto mesh = meshGen.generate(grid);
 
-      // Set functionspace
-      auto functionSpace = atlas::functionspace::NodeColumns(mesh);
-
-      // Set fields
-
-      auto fieldSet = FieldSet{};
-      fieldSet.add(mesh.nodes().global_index());
-      fieldSet.add(mesh.nodes().remote_index());
-      fieldSet.add(mesh.nodes().xy());
-      fieldSet.add(mesh.nodes().lonlat());
-      fieldSet.add(mesh.nodes().ghost());
-      fieldSet.add(mesh.nodes().partition());
-
 
       // Visually inspect the fields.
       // remote indices should be equal at tile boundaries.
@@ -163,9 +150,14 @@ namespace atlas {
       auto gmshConfigXyz = atlas::util::Config("coordinates", "xyz");
       auto gmshConfigLonLat = atlas::util::Config("coordinates", "lonlat");
 
-      gmshConfigXy.set("ghost", "true");
-      gmshConfigXyz.set("ghost", "true");
-      gmshConfigLonLat.set("ghost", "true");
+      gmshConfigXy.set("ghost", true);
+      gmshConfigXy.set("info", true);
+
+      gmshConfigXyz.set("ghost", true);
+      gmshConfigXyz.set("info", true);
+
+      gmshConfigLonLat.set("ghost", true);
+      gmshConfigLonLat.set("info", true);
 
       // Set source gmsh object.
       const auto gmshXy =
@@ -177,27 +169,8 @@ namespace atlas {
 
       // Write gmsh.
       gmshXy.write(mesh);
-      gmshXy.write(fieldSet, functionSpace);
       gmshXyz.write(mesh);
-      gmshXyz.write(fieldSet, functionSpace);
       gmshLonLat.write(mesh);
-      gmshLonLat.write(fieldSet, functionSpace);
-
-
-      /*
-      // Check that node positions match those of equivalent nodal grid.
-      const auto nodeGrid = atlas::Grid("CS-LFR-L-6");
-      const auto viewNodesXy = array::make_view<double, 2>(mesh.nodes().xy());
-
-
-      idx_t iNode = 0;
-      for (auto& xy : nodeGrid.xy()) {
-
-          is_approximately_equal(xy.x(), viewNodesXy(iNode, XX), 1e-12);
-          is_approximately_equal(xy.y(), viewNodesXy(iNode, YY), 1e-12);
-          ++iNode;
-        }
-    */
 
     }
 

--- a/src/tests/grid/test_cubedsphere.cc
+++ b/src/tests/grid/test_cubedsphere.cc
@@ -101,7 +101,7 @@ namespace atlas {
       // I expect this will be replaced by some more aggressive tests.
 
       // Set grid.
-      const auto grid = atlas::Grid("CS-LFR-C-24");
+      const auto grid = atlas::Grid("CS-LFR-C-12");
 
       atlas::Log::info() << grid.name() << std::endl;
       atlas::Log::info() << grid.size() << std::endl;
@@ -123,8 +123,6 @@ namespace atlas {
       fieldSet.add(mesh.nodes().lonlat());
       fieldSet.add(mesh.nodes().ghost());
       fieldSet.add(mesh.nodes().partition());
-      //fieldSet.add(functionSpace.ghost());
-      //fieldSet.add(functionSpace->lonlat());
 
 
       // Visually inspect the fields.
@@ -146,11 +144,11 @@ namespace atlas {
 
       // Write gmsh.
       gmshXy.write(mesh);
-      gmshXy.write(fieldSet);
+      gmshXy.write(fieldSet, functionSpace);
       gmshXyz.write(mesh);
-      gmshXyz.write(fieldSet);
+      gmshXyz.write(fieldSet, functionSpace);
       gmshLonLat.write(mesh);
-      gmshLonLat.write(fieldSet);
+      gmshLonLat.write(fieldSet, functionSpace);
 
 
       /*

--- a/src/tests/grid/test_cubedsphere.cc
+++ b/src/tests/grid/test_cubedsphere.cc
@@ -79,18 +79,18 @@ namespace atlas {
       // Set source gmsh object.
       const auto gmshXy =
         atlas::output::Gmsh("FV3_xy_mesh.msh", gmshConfigXy);
-      const auto gmshXyz =
-        atlas::output::Gmsh("FV3_xyz_mesh.msh", gmshConfigXyz);
-      const auto gmshLonLat =
-        atlas::output::Gmsh("FV3_lonlat_mesh.msh", gmshConfigLonLat);
+      //const auto gmshXyz =
+        //atlas::output::Gmsh("FV3_xyz_mesh.msh", gmshConfigXyz);
+      //const auto gmshLonLat =
+        //atlas::output::Gmsh("FV3_lonlat_mesh.msh", gmshConfigLonLat);
 
       // Write gmsh.
-      gmshXy.write(mesh);
-      gmshXy.write(field);
-      gmshXyz.write(mesh);
-      gmshXyz.write(field);
-      gmshLonLat.write(mesh);
-      gmshLonLat.write(field);
+      //gmshXy.write(mesh);
+      //gmshXy.write(field);
+      //gmshXyz.write(mesh);
+      //gmshXyz.write(field);
+      //gmshLonLat.write(mesh);
+      //gmshLonLat.write(field);
 
 
     }
@@ -101,7 +101,7 @@ namespace atlas {
       // I expect this will be replaced by some more aggressive tests.
 
       // Set grid.
-      const auto grid = atlas::Grid("CS-LFR-C-6");
+      const auto grid = atlas::Grid("CS-LFR-C-24");
 
       atlas::Log::info() << grid.name() << std::endl;
       atlas::Log::info() << grid.size() << std::endl;
@@ -123,6 +123,9 @@ namespace atlas {
       fieldSet.add(mesh.nodes().lonlat());
       fieldSet.add(mesh.nodes().ghost());
       fieldSet.add(mesh.nodes().partition());
+      //fieldSet.add(functionSpace.ghost());
+      //fieldSet.add(functionSpace->lonlat());
+
 
       // Visually inspect the fields.
       // remote indices should be equal at tile boundaries.
@@ -150,9 +153,11 @@ namespace atlas {
       gmshLonLat.write(fieldSet);
 
 
+      /*
       // Check that node positions match those of equivalent nodal grid.
       const auto nodeGrid = atlas::Grid("CS-LFR-L-6");
       const auto viewNodesXy = array::make_view<double, 2>(mesh.nodes().xy());
+
 
       idx_t iNode = 0;
       for (auto& xy : nodeGrid.xy()) {
@@ -161,7 +166,7 @@ namespace atlas {
           is_approximately_equal(xy.y(), viewNodesXy(iNode, YY), 1e-12);
           ++iNode;
         }
-
+    */
 
     }
 

--- a/src/tests/grid/test_cubedsphere.cc
+++ b/src/tests/grid/test_cubedsphere.cc
@@ -90,13 +90,6 @@ namespace atlas {
       // Set functionspace
       auto functionSpace = atlas::functionspace::NodeColumns(mesh);
 
-      auto ghostIdx = mesh.nodes().metadata().get<std::vector<idx_t>>("ghost-global-idx");
-      auto ownedIdx = mesh.nodes().metadata().get<std::vector<idx_t>>("owned-global-idx");
-
-      // Print out ghost global indices with corresponding owned global indices
-      auto ownedIdxIt = ownedIdx.begin();
-      for (auto iGhost : ghostIdx) std::cout << iGhost << " " << *ownedIdxIt++ << std::endl;
-
       // Set field
       auto field = functionSpace.ghost();
 

--- a/src/tests/mesh/CMakeLists.txt
+++ b/src/tests/mesh/CMakeLists.txt
@@ -103,7 +103,7 @@ ecbuild_add_test( TARGET atlas_test_healpixmeshgen
 )
 
 ecbuild_add_test( TARGET atlas_test_cubedsphere_meshgen
-  MPI        4
+  MPI        8
   CONDITION  eckit_HAVE_MPI
   SOURCES test_cubedsphere_meshgen.cc
   LIBS atlas

--- a/src/tests/mesh/CMakeLists.txt
+++ b/src/tests/mesh/CMakeLists.txt
@@ -102,6 +102,14 @@ ecbuild_add_test( TARGET atlas_test_healpixmeshgen
   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
 )
 
+ecbuild_add_test( TARGET atlas_test_cubedsphere_meshgen
+  MPI        4
+  CONDITION  eckit_HAVE_MPI
+  SOURCES test_cubedsphere_meshgen.cc
+  LIBS atlas
+  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+)
+
 
 ecbuild_add_executable( TARGET atlas_test_mesh_reorder
   SOURCES  test_mesh_reorder.cc

--- a/src/tests/mesh/test_cubedsphere_meshgen.cc
+++ b/src/tests/mesh/test_cubedsphere_meshgen.cc
@@ -1,0 +1,88 @@
+/*
+ * (C) Crown Copyright 2021 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "atlas/array/MakeView.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/field/FieldSet.h"
+#include "atlas/grid.h"
+#include "atlas/grid/Tiles.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
+#include "atlas/grid/Partitioner.h"
+#include "atlas/grid/detail/partitioner/CubedSpherePartitioner.h"
+#include "atlas/option.h"
+#include "atlas/util/CoordinateEnums.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+  namespace test {
+
+    CASE("cubedsphere_mesh_test") {
+
+      // Set grid.
+      const auto grid = atlas::Grid("CS-LFR-C-16");
+
+      // Set partitioners.
+      const auto csPart = grid::Partitioner("cubed_sphere", mpi::size());
+      const auto erPart = grid::Partitioner("equal_regions", mpi::size());
+
+      // Set distributions
+      const auto csDist = grid::Distribution(grid, csPart);
+      const auto erDist = grid::Distribution(grid, erPart);
+
+
+      // Set meshes.
+      const auto csMesh = atlas::MeshGenerator("cubedsphere").generate(grid);
+      const auto erMesh = atlas::MeshGenerator("cubedsphere").generate(grid, erDist);
+
+
+      // Set gmsh config.
+      auto gmshConfigXy = atlas::util::Config("coordinates", "xy");
+      auto gmshConfigXyz = atlas::util::Config("coordinates", "xyz");
+      auto gmshConfigLonLat = atlas::util::Config("coordinates", "lonlat");
+
+      gmshConfigXy.set("ghost", true);
+      gmshConfigXy.set("info", true);
+
+      gmshConfigXyz.set("ghost", true);
+      gmshConfigXyz.set("info", true);
+
+      gmshConfigLonLat.set("ghost", true);
+      gmshConfigLonLat.set("info", true);
+
+      // Set gmsh objects.
+      auto gmshXy = atlas::output::Gmsh("cs_xy_mesh.msh", gmshConfigXy);
+      auto gmshXyz = atlas::output::Gmsh("cs_xyz_mesh.msh", gmshConfigXyz);
+      auto gmshLonLat = atlas::output::Gmsh("cs_lonlat_mesh.msh", gmshConfigLonLat);
+
+      // Write gmsh.
+      gmshXy.write(csMesh);
+      gmshXyz.write(csMesh);
+      gmshLonLat.write(csMesh);
+
+      // Set gmsh objects.
+      gmshXy = atlas::output::Gmsh("er_xy_mesh.msh", gmshConfigXy);
+      gmshXyz = atlas::output::Gmsh("er_xyz_mesh.msh", gmshConfigXyz);
+      gmshLonLat = atlas::output::Gmsh("er_lonlat_mesh.msh", gmshConfigLonLat);
+
+      // Write gmsh.
+      gmshXy.write(erMesh);
+      gmshXyz.write(erMesh);
+      gmshLonLat.write(erMesh);
+
+    }
+
+
+
+    }  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+  return atlas::test::run( argc, argv );
+}

--- a/src/tests/mesh/test_cubedsphere_meshgen.cc
+++ b/src/tests/mesh/test_cubedsphere_meshgen.cc
@@ -28,18 +28,15 @@ namespace atlas {
       // Set grid.
       const auto grid = atlas::Grid("CS-LFR-C-16");
 
-      // Set partitioners.
-      const auto csPart = grid::Partitioner("cubed_sphere", mpi::size());
-      const auto erPart = grid::Partitioner("equal_regions", mpi::size());
+      // Set mesh config.
+      auto meshConfig = util::Config("partitioner", "equal_regions");
 
-      // Set distributions
-      const auto csDist = grid::Distribution(grid, csPart);
-      const auto erDist = grid::Distribution(grid, erPart);
+      // Set mesh generators.
+      const auto csMeshgen = atlas::MeshGenerator("cubedsphere"); // defaults to cubed sphere partitioner.
+      const auto erMeshgen = atlas::MeshGenerator("cubedsphere", meshConfig); // Equal regions partitioner.
 
-
-      // Set meshes.
-      const auto csMesh = atlas::MeshGenerator("cubedsphere").generate(grid);
-      const auto erMesh = atlas::MeshGenerator("cubedsphere").generate(grid, erDist);
+      const auto csMesh = csMeshgen.generate(grid);
+      const auto erMesh = erMeshgen.generate(grid);
 
 
       // Set gmsh config.


### PR DESCRIPTION
Hi @wdeconinck , I'm hoping you can provide me with some sage advice. (I've invited others along in case they can help or are interested).

I'm attempting to implement a multi-PE cubed sphere mesh-generator (this draft PR). And I think I'm having some trouble with the book-keeping. I'm not sure if there's a bug in my algorithm, or gap in my understanding of parallel mesh generators.

The algorithm places cells at the xy grid coordinates, then generates nodes around them. I've put a fairly detailed description of the steps at the top of the  `CubedSphereMeshGenerator::generate` definition in `src/atlas/meshgenerator/detail/CubedSphereMeshGenerator.cc`.

When I run it, it seems to make a nice looking mesh in gmsh. Here's an 8 PE mesh of an N24 grid with the equal regions partitioner:
![PE8mesh](https://user-images.githubusercontent.com/20695114/127898175-d53f1cac-1d4e-44f1-b293-24c78989f300.png)

However, if I look at the nodes fields, they come out as garbage. Here's the `nodes().ghost()` field:
![ghost-garbage](https://user-images.githubusercontent.com/20695114/127898293-bd0ecb68-7ff3-44b2-b982-e1667a6c4a03.png)


If I run the exact same test on 1PE, everything comes out fine. Here's what the ghost field _should_ look like:
![ghost-good](https://user-images.githubusercontent.com/20695114/127898401-a90cdebe-0d2d-42d9-b93c-52d8a63bf40a.png)

And just for good measure, here's what my remote index field looks like on 1PE:
![remote-idx-good](https://user-images.githubusercontent.com/20695114/127898584-8623b6b0-8fb1-4c9e-b4fd-3a2f8f91f535.png)



I wonder if I'm making any incorrect assumptions on the data I need to attribute to nodes and cells:

Here, each cell has:
* a unique global index from 1 to nCells
* a unique local index from 0 to however many cells are on the partition minus 1. (implied by data order)
* a partition ID.

Just to complicate things there are two types of ghost node.
* Type-A, which lie on edge and corners. Only one tile can own the edge nodes. This is defined at a global level by the `CubedSphereTiles` class.
* Type-B, which are at the boundaries between partitions. This are defined at a local level and may change with the partitioner.

Each owned and Type-A ghost has:
* a unique global index from 1 to nNodes (including edge ghosts)
* a unique local index (implied by data order)
* a remote index pointing to an owner node, if applicable.
* the partition ID of the owner node.

Type B ghost are similar, but they inherit the global ID of the owner node. All nodes also have `ghost` and `flags` field values set.

The node global ID order goes: owned, Type-A ghost.
The node local ID order goes: owned, Type-A ghost, Type-B ghost.

I've done my best to figure out what metadata needs to be set at the end, but it was mostly guesswork.

It's also possible I've made an error in `case_cubed_sphere_generic_mesh_test` in `src/tests/grid/test_cubedsphere.cc`


It's quite possible I've got a bug in my algorithm, but I need to first make sure that I haven't made any obvious assumptions on how mesh generators are supposed to work.
