### PR TITLE
Allow extended halos on cubed-sphere dual mesh

### DIFF
--- a/src/atlas/functionspace/CubedSphereColumns.cc
+++ b/src/atlas/functionspace/CubedSphereColumns.cc
@@ -151,6 +151,11 @@ idx_t CubedSphereColumns<BaseFunctionSpace>::index(idx_t t, idx_t i, idx_t j) co
 }
 
 template <typename BaseFunctionSpace>
+bool CubedSphereColumns<BaseFunctionSpace>::is_valid_index(idx_t t, idx_t i, idx_t j) const {
+    return cubedSphereColumnsHandle_.get()->is_valid_index(t, i, j);
+}
+
+template <typename BaseFunctionSpace>
 Field CubedSphereColumns<BaseFunctionSpace>::tij() const {
     return cubedSphereColumnsHandle_.get()->tij();
 }

--- a/src/atlas/functionspace/CubedSphereColumns.h
+++ b/src/atlas/functionspace/CubedSphereColumns.h
@@ -54,6 +54,9 @@ public:
     /// Return array_view index for (t, i, j).
     idx_t index(idx_t t, idx_t i, idx_t j) const;
 
+    /// Return true if (t, i, j) is a valid index.
+    bool is_valid_index(idx_t t, idx_t i, idx_t j) const;
+
     /// Return tij field.
     Field tij() const;
 

--- a/src/atlas/functionspace/detail/CubedSphereStructure.cc
+++ b/src/atlas/functionspace/detail/CubedSphereStructure.cc
@@ -120,6 +120,29 @@ idx_t CubedSphereStructure::index(idx_t t, idx_t i, idx_t j) const {
     return tijToIdx_[static_cast<size_t>(t)][vecIndex(t, i, j)];
 }
 
+bool CubedSphereStructure::is_valid_index(idx_t t, idx_t i, idx_t j) const {
+
+
+    // Check if t is in range.
+    if (t < 0 || t > 5) {
+        return false;
+    }
+
+    // Check if i and j are in range in index method.
+    if ( i < i_begin(t) || i >= i_end(t) ||
+         j < j_begin(t) || j >= j_end(t)) {
+        return false;
+    }
+
+    // Check if (t, i, j) is a valid index.
+    if (index(t, i, j) == invalid_index()) {
+        return false;
+    }
+
+    return true;
+
+}
+
 Field CubedSphereStructure::tij() const {
     return tij_;
 }

--- a/src/atlas/functionspace/detail/CubedSphereStructure.h
+++ b/src/atlas/functionspace/detail/CubedSphereStructure.h
@@ -53,6 +53,10 @@ public:
     /// Return array_view index for (t, i, j).
     idx_t index(idx_t t, idx_t i, idx_t j) const;
 
+    /// Return true if (t, i, j) is a valid index.
+    bool is_valid_index(idx_t t, idx_t i, idx_t j) const;
+
+
     /// Return ijt field.
     Field tij() const;
 

--- a/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.cc
@@ -367,9 +367,9 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
 
     // Figure out element types.
     // Set first element type. ( first = type, second = count )
-    // Types: 2 = line, 3 = triangle, 4 = quad.
-    auto typeCounts = std::vector<std::pair<size_t, idx_t>>{
-                        std::make_pair(nodeLists[0].nodes.size(), 1)};
+    enum struct ElemType : size_t {LINE = 2, TRIANGLE = 3, QUADRILATERAL = 4};
+    auto typeCounts = std::vector<std::pair<ElemType, idx_t>>{
+        std::make_pair(static_cast<ElemType>(nodeLists[0].nodes.size()), 1)};
 
     // Count the number of consecutive lines, triangles or quadtrilaterals in dual mesh.
     // This is an attempt to keep dual mesh cells in the same order as mesh nodes.
@@ -377,7 +377,7 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
     for (size_t idx = 1; idx < nodeLists.size(); ++idx) {
 
         // Get the element type.
-        const auto elemType = nodeLists[idx].nodes.size();
+        const auto elemType = static_cast<ElemType>(nodeLists[idx].nodes.size());
 
         // Increment counter if this elemType is the same as last one
         if (elemType == typeCounts.back().first) {
@@ -397,23 +397,23 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
         // Select element type.
         switch (typeCount.first) {
             // Add a block of lines.
-            case 2: {
+            case ElemType::LINE : {
                 cells.add(new mesh::temporary::Line(), typeCount.second);
                 break;
             }
             // Add a block of triangles.
-            case 3: {
+            case ElemType::TRIANGLE : {
                 cells.add(new mesh::temporary::Triangle(), typeCount.second);
                 break;
             }
             // Add a block of quadrilaterals.
-            case 4: {
+        case ElemType::QUADRILATERAL : {
                 cells.add(new mesh::temporary::Quadrilateral(), typeCount.second);
                 break;
             }
             default: {
                 ATLAS_THROW_EXCEPTION("Unknown element type with " +
-                                      std::to_string(typeCount.first) +
+                                      std::to_string(static_cast<size_t>(typeCount.first)) +
                                       " nodes.");
                 break;
             }

--- a/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.cc
+++ b/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.cc
@@ -123,14 +123,6 @@ void CubedSphereDualMeshGenerator::generate(const Grid& grid, const grid::Distri
         throw_Exception("CubedSphereDualMeshGenerator will only work with a cell-centroid grid.", Here());
     }
 
-    // Enforce compatible halo size.
-    if (options.get<idx_t>("halo") != 0) {
-        throw_Exception(
-            "Halo size CubedSphereDualMeshGenerator is currently "
-            "limited to 0.",
-            Here());
-    }
-
     // Clone some grid properties.
     setGrid(mesh, csGrid, distribution);
 
@@ -141,11 +133,133 @@ void CubedSphereDualMeshGenerator::generate(const Grid& grid, const grid::Distri
 
 namespace {
 
+// (i, j) pair
+class IJ {
+public:
+    IJ(idx_t i, idx_t j) : i_(i), j_(j) {}
+    idx_t i() const {return i_;}
+    idx_t j() const {return j_;}
+    idx_t& i() {return i_;}
+    idx_t& j() {return j_;}
+    IJ operator+(const IJ& ij) const {return IJ{i() + ij.i(), j() + ij.j()};}
+    IJ operator-(const IJ& ij) const {return IJ{i() - ij.i(), j() - ij.j()};}
+private:
+    idx_t i_{};
+    idx_t j_{};
+};
+
 // Helper function to copy fields.
 template <typename Value, int Rank>
 void copyField(const Field& sourceField, Field& targetField) {
     // Assign source field values to target field.
     array::make_view<Value, Rank>(targetField).assign(array::make_view<Value, Rank>(sourceField));
+}
+
+// Get the surrounding node (i, j) pairs from a cell (i, j) pair.
+std::vector<IJ> getIjNodes(const IJ& ijCell, idx_t N) {
+
+    // Rotate ij 90 degrees anitclockwise about ijPivot.
+    auto rotateAnticlockwise = [&](const IJ& ij, const IJ& ijPivot){
+
+        const auto ijTemp = ij - ijPivot;
+        return IJ{-ijTemp.j(), ijTemp.i()} + ijPivot;
+    };
+
+    // Rotate ij 90 degrees clockwise about ijPivot.
+    auto rotateClockwise = [&](const IJ& ij, const IJ& ijPivot){
+
+        const auto ijTemp = ij - ijPivot;
+        return IJ{ijTemp.j(), -ijTemp.i()} + ijPivot;
+    };
+
+    // Set standard surrounding nodes.
+    auto ijNodes = std::vector<IJ>{{ijCell.i() - 1, ijCell.j() - 1},
+                                   {ijCell.i()    , ijCell.j() - 1},
+                                   {ijCell.i()    , ijCell.j()    },
+                                   {ijCell.i() - 1, ijCell.j()    }};
+
+    // Modify nodes that lie in invalid corners of ij space.
+    // Either remove a node to make cell triangular, or rotate two of the
+    // nodes out of the forbidden space.
+
+    // Bottom-left corner.
+    if (ijCell.i() <= 0 && ijCell.j() <= 0) {
+
+        // Triangle.
+        if (ijCell.i() == 0 && ijCell.j() == 0) {
+            ijNodes.erase(ijNodes.begin());
+        }
+        // Quad (i)
+        else if (ijCell.i() == 0) {
+            ijNodes[0] = rotateClockwise(ijNodes[1], IJ{0, 0});
+            ijNodes[3] = rotateClockwise(ijNodes[2], IJ{0, 0});
+        }
+        else {
+        // Quad (ii)
+            ijNodes[0] = rotateAnticlockwise(ijNodes[3], IJ{0, 0});
+            ijNodes[1] = rotateAnticlockwise(ijNodes[2], IJ{0, 0});
+        }
+    }
+    // Bottom-right corner.
+    else if (ijCell.i() >= N && ijCell.j() <= 0) {
+
+        // Triangle.
+        if (ijCell.i() == N && ijCell.j() == 0) {
+            ijNodes.erase(ijNodes.begin() + 1);
+        }
+        // Quad (i)
+        else if (ijCell.j() == 0) {
+            ijNodes[0] = rotateClockwise(ijNodes[3], IJ{N - 1, 0});
+            ijNodes[1] = rotateClockwise(ijNodes[2], IJ{N - 1, 0});
+        }
+        // Quad (ii)
+        else {
+            ijNodes[1] = rotateAnticlockwise(ijNodes[0], IJ{N - 1, 0});
+            ijNodes[2] = rotateAnticlockwise(ijNodes[3], IJ{N - 1, 0});
+        }
+
+    }
+    // Top-right corner.
+    else if (ijCell.i() >= N && ijCell.j() >= N) {
+
+        // Triangle.
+        if (ijCell.i() == N && ijCell.j() == N) {
+            ijNodes.erase(ijNodes.begin() + 2);
+        }
+        // Quad (i)
+        else if (ijCell.i() == N) {
+            ijNodes[1] = rotateClockwise(ijNodes[0], IJ{N - 1, N - 1});
+            ijNodes[2] = rotateClockwise(ijNodes[3], IJ{N - 1, N - 1});
+        }
+        // Quad (ii)
+        else {
+            ijNodes[2] = rotateAnticlockwise(ijNodes[1], IJ{N - 1, N - 1});
+            ijNodes[3] = rotateAnticlockwise(ijNodes[0], IJ{N - 1, N - 1});
+        }
+
+    }
+    // Top-left corner.
+    else if (ijCell.i() <= 0 && ijCell.j() >= N) {
+
+        // Triangle.
+        if (ijCell.i() == 0 && ijCell.j() == N) {
+            ijNodes.erase(ijNodes.begin() + 3);
+        }
+        // Quad (i)
+        else if (ijCell.j() == N) {
+            ijNodes[2] = rotateClockwise(ijNodes[1], IJ{0, N - 1});
+            ijNodes[3] = rotateClockwise(ijNodes[0], IJ{0, N - 1});
+
+        }
+        // Quad (ii)
+        else {
+            ijNodes[0] = rotateAnticlockwise(ijNodes[1], IJ{0, N - 1});
+            ijNodes[3] = rotateAnticlockwise(ijNodes[2], IJ{0, N - 1});
+        }
+    }
+
+    return ijNodes;
+
 }
 
 }  // namespace
@@ -154,6 +268,7 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
                                                  Mesh& mesh) const {
     ATLAS_TRACE("CubedSphereDualMeshGenerator::generate");
 
+    using Topology = atlas::mesh::Nodes::Topology;
     using namespace detail::cubedsphere;
 
     const idx_t N     = csGrid.N();
@@ -163,36 +278,36 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
     // Create a cubed-sphere mesh.
     //--------------------------------------------------------------------------
 
-    // Generate cubed sphere mesh.
-    auto csOptions = options;
-    csOptions.set("halo", nHalo + 1);
-    const auto csMesh = MeshGenerator("cubedsphere", csOptions).generate(csGrid, distribution);
+    // Generate cubed sphere primal mesh.
+    auto primalOptions = options;
+    primalOptions.set("halo", nHalo + 1);
+    const auto primalMesh = MeshGenerator("cubedsphere", primalOptions).generate(csGrid, distribution);
 
-    // Generate fucntionspaces cubed sphere mesh.
-    const auto csCellsFunctionSpace = functionspace::CubedSphereCellColumns(csMesh);
-    const auto csNodesFunctionSpace = functionspace::CubedSphereNodeColumns(csMesh);
-    const auto& csCells             = csCellsFunctionSpace.cells();
-    const auto& csNodes             = csNodesFunctionSpace.nodes();
+    // Generate fucntionspaces for cubed sphere primal mesh.
+    const auto primalCellsFunctionSpace = functionspace::CubedSphereCellColumns(primalMesh);
+    const auto primalNodesFunctionSpace = functionspace::CubedSphereNodeColumns(primalMesh);
+    const auto& primalCells             = primalCellsFunctionSpace.cells();
+    const auto& primalNodes             = primalNodesFunctionSpace.nodes();
 
     //--------------------------------------------------------------------------
     // Set dual mesh nodes (easy part).
     //--------------------------------------------------------------------------
 
     auto& nodes = mesh.nodes();
-    nodes.resize(csCellsFunctionSpace.size());
+    nodes.resize(primalCellsFunctionSpace.size());
 
     nodes.add(Field("tij", array::make_datatype<idx_t>(), array::make_shape(nodes.size(), 3)));
 
     // Copy mesh fields to dual mesh.
-    copyField<gidx_t, 1>(csCells.global_index(), nodes.global_index());
-    copyField<idx_t, 1>(csCells.remote_index(), nodes.remote_index());
-    copyField<int, 1>(csCells.partition(), nodes.partition());
-    copyField<int, 1>(csCells.halo(), nodes.halo());
-    copyField<int, 1>(csCells.flags(), nodes.flags());
-    copyField<int, 1>(csCells.field("ghost"), nodes.ghost());
-    copyField<double, 2>(csCells.field("xy"), nodes.xy());
-    copyField<double, 2>(csCells.field("lonlat"), nodes.lonlat());
-    copyField<idx_t, 2>(csCells.field("tij"), nodes.field("tij"));
+    copyField<gidx_t, 1>(primalCells.global_index(), nodes.global_index());
+    copyField<idx_t, 1>(primalCells.remote_index(), nodes.remote_index());
+    copyField<int, 1>(primalCells.partition(), nodes.partition());
+    copyField<int, 1>(primalCells.halo(), nodes.halo());
+    copyField<int, 1>(primalCells.flags(), nodes.flags());
+    copyField<int, 1>(primalCells.field("ghost"), nodes.ghost());
+    copyField<double, 2>(primalCells.field("xy"), nodes.xy());
+    copyField<double, 2>(primalCells.field("lonlat"), nodes.lonlat());
+    copyField<idx_t, 2>(primalCells.field("tij"), nodes.field("tij"));
 
     // Need to decrement halo by one.
     auto nodesHalo  = array::make_view<int, 1>(nodes.halo());
@@ -206,37 +321,63 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
     //--------------------------------------------------------------------------
 
     // Make views to cubed sphere nodes.
-    const auto csNodesHalo = array::make_view<int, 1>(csNodes.halo());
-    const auto csNodesTij  = array::make_view<idx_t, 2>(csNodes.field("tij"));
+    const auto primalNodesHalo = array::make_view<int, 1>(primalNodes.halo());
+    const auto primalNodesTij  = array::make_view<idx_t, 2>(primalNodes.field("tij"));
 
-    // Figure out element types.
-    enum struct ElemType
-    {
-        tri,
-        quad
-    };
-    const auto getType = [&](idx_t idx) -> ElemType {
-        // Nodes of csMesh are cells of dual mesh.
-        const idx_t i   = csNodesTij(idx, Coordinates::I);
-        const idx_t j   = csNodesTij(idx, Coordinates::J);
-        auto cornerCell = (i == 0 && j == 0) || (i == N && j == 0) || (i == N && j == N) || (i == 0 && j == N);
-        return cornerCell ? ElemType::tri : ElemType::quad;
+    // Loop over all nodes of primal mesh, excluding outermost halo.
+    // Find dual mesh nodes around primal mesh nodes.
+    // Note: some halo cells near corners may be incomplete.
+
+    // Set of nodes around a cell.
+    struct NodeList {
+        std::vector<idx_t> nodes{};          // Node indices.
+        bool               incomplete{};    // True if nodes are missing.
     };
 
-    // Set first element type. ( first = type, second = count )
-    auto typeCounts = std::vector<std::pair<ElemType, idx_t> >{std::make_pair(getType(0), 1)};
+    auto nodeLists = std::vector<NodeList>{};
 
-    // Count the number of consecutive triangles and quadtrilaterals in dual mesh.
-    // This is an attempt to keep dual mesh cells in the same order as mesh nodes.
-    // Otherwise, the halo exchange bookkeeping is invalidated.
-    for (idx_t idx = 1; idx < csNodes.size(); ++idx) {
+    for (idx_t idx = 0; idx < primalNodes.size(); ++idx) {
         // Exclude outer ring of cubed sphere mesh halo.
-        if (csNodesHalo(idx) == nHalo + 1) {
+        if (primalNodesHalo(idx) == nHalo + 1) {
             break;
         }
 
+        nodeLists.emplace_back();
+        auto& nodeList = nodeLists.back();
+
+        // Get tij of cell.
+        const auto tCell = primalNodesTij(idx, Coordinates::T);
+        const auto ijCell = IJ{primalNodesTij(idx, Coordinates::I),
+                               primalNodesTij(idx, Coordinates::J)};
+
+        // Get ij of surrounding nodes.
+        auto ijNodes = getIjNodes(ijCell, N);
+
+        // Add indices to nodes vector.
+        for (const auto& ijNode : ijNodes) {
+            if (primalCellsFunctionSpace.is_valid_index(tCell, ijNode.i(), ijNode.j())) {
+                nodeList.nodes.push_back(
+                    primalCellsFunctionSpace.index(tCell, ijNode.i(), ijNode.j()));
+            }
+            else {
+                nodeList.incomplete = true;
+            }
+        }
+    }
+
+    // Figure out element types.
+    // Set first element type. ( first = type, second = count )
+    // Types: 2 = line, 3 = triangle, 4 = quad.
+    auto typeCounts = std::vector<std::pair<size_t, idx_t>>{
+                        std::make_pair(nodeLists[0].nodes.size(), 1)};
+
+    // Count the number of consecutive lines, triangles or quadtrilaterals in dual mesh.
+    // This is an attempt to keep dual mesh cells in the same order as mesh nodes.
+    // Otherwise, the halo exchange bookkeeping is invalidated.
+    for (size_t idx = 1; idx < nodeLists.size(); ++idx) {
+
         // Get the element type.
-        const auto elemType = getType(idx);
+        const auto elemType = nodeLists[idx].nodes.size();
 
         // Increment counter if this elemType is the same as last one
         if (elemType == typeCounts.back().first) {
@@ -255,14 +396,25 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
     for (const auto& typeCount : typeCounts) {
         // Select element type.
         switch (typeCount.first) {
-            // Add a batch of triangles.
-            case ElemType::tri: {
+            // Add a block of lines.
+            case 2: {
+                cells.add(new mesh::temporary::Line(), typeCount.second);
+                break;
+            }
+            // Add a block of triangles.
+            case 3: {
                 cells.add(new mesh::temporary::Triangle(), typeCount.second);
                 break;
             }
-            // Add a batch quadrilaterals.
-            case ElemType::quad: {
+            // Add a block of quadrilaterals.
+            case 4: {
                 cells.add(new mesh::temporary::Quadrilateral(), typeCount.second);
+                break;
+            }
+            default: {
+                ATLAS_THROW_EXCEPTION("Unknown element type with " +
+                                      std::to_string(typeCount.first) +
+                                      " nodes.");
                 break;
             }
         }
@@ -272,84 +424,98 @@ void CubedSphereDualMeshGenerator::generate_mesh(const CubedSphereGrid& csGrid, 
 
     // Add extra fields to cells.
     cells.add(Field("tij", array::make_datatype<idx_t>(), array::make_shape(cells.size(), 3)));
-
     cells.add(Field("xy", array::make_datatype<double>(), array::make_shape(cells.size(), 2)));
-
     cells.add(Field("lonlat", array::make_datatype<double>(), array::make_shape(cells.size(), 2)));
-
     cells.add(Field("ghost", array::make_datatype<int>(), array::make_shape(cells.size())));
 
     // Copy dual cells fields from nodes.
-    copyField<gidx_t, 1>(csNodes.global_index(), cells.global_index());
-    copyField<idx_t, 1>(csNodes.remote_index(), cells.remote_index());
-    copyField<int, 1>(csNodes.partition(), cells.partition());
-    copyField<int, 1>(csNodes.ghost(), cells.field("ghost"));
-    copyField<int, 1>(csNodes.halo(), cells.halo());
-    copyField<int, 1>(csNodes.flags(), cells.flags());
-    copyField<idx_t, 2>(csNodes.field("tij"), cells.field("tij"));
-    copyField<double, 2>(csNodes.xy(), cells.field("xy"));
-    copyField<double, 2>(csNodes.lonlat(), cells.field("lonlat"));
+    copyField<gidx_t, 1>(primalNodes.global_index(), cells.global_index());
+    copyField<idx_t, 1>(primalNodes.remote_index(), cells.remote_index());
+    copyField<int, 1>(primalNodes.partition(), cells.partition());
+    copyField<int, 1>(primalNodes.ghost(), cells.field("ghost"));
+    copyField<int, 1>(primalNodes.halo(), cells.halo());
+    copyField<int, 1>(primalNodes.flags(), cells.flags());
+    copyField<idx_t, 2>(primalNodes.field("tij"), cells.field("tij"));
+    copyField<double, 2>(primalNodes.xy(), cells.field("xy"));
+    copyField<double, 2>(primalNodes.lonlat(), cells.field("lonlat"));
+
+    // Get view of flags field.
+    auto dualCellsFlags = array::make_view<int, 1>(cells.flags());
 
     // Get node connectivity.
     auto& nodeConnectivity = cells.node_connectivity();
 
     // Loop over dual mesh cells and set connectivity.
     for (idx_t idx = 0; idx < nCells; ++idx) {
-        const idx_t t = csNodesTij(idx, Coordinates::T);
-        const idx_t i = csNodesTij(idx, Coordinates::I);
-        const idx_t j = csNodesTij(idx, Coordinates::J);
 
+        // Set connectivity.
+        nodeConnectivity.set(idx, nodeLists[idx].nodes.data());
 
-        // Declare vector of surrounding nodes.
-        auto cellNodes = std::vector<idx_t>{};
-
-        // Get number of nodes per element.
-        const auto nNodes = cells.node_connectivity().row(idx).size();
-        // Element is a triangle.
-        if (nNodes == 3) {
-            // Bottom-left corner.
-            if (i == 0 && j == 0) {
-                cellNodes = {csCellsFunctionSpace.index(t, 0, -1), csCellsFunctionSpace.index(t, 0, 0),
-                             csCellsFunctionSpace.index(t, -1, 0)};
-            }
-            // Bottom-right corner.
-            else if (i == N && j == 0) {
-                cellNodes = {csCellsFunctionSpace.index(t, N - 1, -1), csCellsFunctionSpace.index(t, N, 0),
-                             csCellsFunctionSpace.index(t, N - 1, 0)};
-            }
-            // Top-right corner.
-            else if (i == N && j == N) {
-                cellNodes = {csCellsFunctionSpace.index(t, N - 1, N - 1), csCellsFunctionSpace.index(t, N, N - 1),
-                             csCellsFunctionSpace.index(t, N - 1, N)};
-            }
-            // Top-left corner.
-            else {
-                cellNodes = {csCellsFunctionSpace.index(t, -1, N - 1), csCellsFunctionSpace.index(t, 0, N - 1),
-                             csCellsFunctionSpace.index(t, 0, N)};
-            }
+        // Set invalid flag if cell is incomplete.
+        if (nodeLists[idx].incomplete) {
+            Topology::set(dualCellsFlags(idx), Topology::INVALID);
         }
-        // Element is a quadtrilateral.
-        else if (nNodes == 4) {
-            cellNodes = {csCellsFunctionSpace.index(t, i - 1, j - 1), csCellsFunctionSpace.index(t, i, j - 1),
-                         csCellsFunctionSpace.index(t, i, j), csCellsFunctionSpace.index(t, i - 1, j)};
-        }
-        // Couldn't determine element type.
-        else {
-            ATLAS_THROW_EXCEPTION("Could not determine element type for cell " + std::to_string(idx) + ".";);
-        }
-
-        nodeConnectivity.set(idx, cellNodes.data());
     }
 
     // Set metadata.
+    set_metadata(mesh);
+
+    return;
+}
+
+// -----------------------------------------------------------------------------
+
+void CubedSphereDualMeshGenerator::set_metadata(Mesh& mesh) const {
+
+    const auto nHalo = options.get<int>("halo");
+
+    // Set basic halo metadata.
     mesh.metadata().set("halo", nHalo);
     mesh.metadata().set("halo_locked", true);
     mesh.nodes().metadata().set("parallel", true);
     mesh.cells().metadata().set("parallel", true);
 
-    return;
-}
+    // Loop over nodes and count number of halo elements.
+    auto nNodes = std::vector<idx_t>(nHalo + 2, 0);
+    const auto nodeHalo = array::make_view<int, 1>(mesh.nodes().halo());
+    for (idx_t i = 0; i < mesh.nodes().size(); ++i) {
+        ++nNodes[static_cast<size_t>(nodeHalo(i))];
+    }
+    std::partial_sum(nNodes.begin(), nNodes.end(), nNodes.begin());
 
+    // Set node halo metadata.
+    for (size_t i = 0; i < nNodes.size(); ++i) {
+        const auto str = "nb_nodes_including_halo[" + std::to_string(i) + "]";
+        mesh.metadata().set(str, nNodes[i]);
+    }
+
+
+    // Loop over cells and count number of halo elements.
+    auto nCells = std::vector<std::vector<idx_t>>(
+        mesh.cells().nb_types(), std::vector<idx_t>(nHalo + 1, 0));
+    const auto cellHalo = array::make_view<int, 1>(mesh.cells().halo());
+
+    for (idx_t i = 0; i < mesh.cells().nb_types(); ++i){
+        const auto& elems = mesh.cells().elements(i);
+        for (idx_t j = elems.begin(); j < elems.end(); ++j) {
+            ++nCells[static_cast<size_t>(i)][static_cast<size_t>(cellHalo(j))];
+
+        }
+        std::partial_sum(nCells[static_cast<size_t>(i)].begin(),
+                         nCells[static_cast<size_t>(i)].end(),
+                         nCells[static_cast<size_t>(i)].begin());
+    }
+
+    // Set cell halo metadata.
+    for (size_t i = 0; i < nCells.size(); ++i) {
+        for (size_t j = 0; j < nCells[i].size(); ++j) {
+            const auto str =
+                "nb_cells_including_halo[" + std::to_string(i) + "][" + std::to_string(j) + "]";
+            mesh.metadata().set(str, nCells[i][j]);
+        }
+    }
+
+}
 
 // -----------------------------------------------------------------------------
 

--- a/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.h
+++ b/src/atlas/meshgenerator/detail/CubedSphereDualMeshGenerator.h
@@ -56,6 +56,8 @@ private:
 
     void generate_mesh(const CubedSphereGrid&, const grid::Distribution&, Mesh&) const;
 
+    void set_metadata(Mesh&) const;
+
 private:
     util::Metadata options;
 };

--- a/src/tests/functionspace/test_cubedsphere_functionspace.cc
+++ b/src/tests/functionspace/test_cubedsphere_functionspace.cc
@@ -134,9 +134,9 @@ CASE("cubedsphere_mesh_functionspace") {
 
     // Set dual mesh generator.
     const auto dualMeshGenEqualRegions =
-        MeshGenerator("cubedsphere_dual", meshConfigEqualRegions | util::Config("halo", 0));
+        MeshGenerator("cubedsphere_dual", meshConfigEqualRegions);
     const auto dualMeshGenCubedSphere =
-        MeshGenerator("cubedsphere_dual", meshConfigCubedSphere | util::Config("halo", 0));
+        MeshGenerator("cubedsphere_dual", meshConfigCubedSphere);
 
     // Set mesh
     const auto meshEqualRegions = meshGenEqualRegions.generate(grid);
@@ -162,6 +162,8 @@ CASE("cubedsphere_mesh_functionspace") {
     SECTION("CellColumns: cubedsphere") { testFunctionSpace(cubedSphereCellColumns); }
     SECTION("NodeColumns: equal_regions") { testFunctionSpace(equalRegionsNodeColumns); }
     SECTION("NodeColumns: cubedsphere") { testFunctionSpace(cubedSphereNodeColumns); }
+    SECTION("CellColumns: dual mesh, equal_regions") { testFunctionSpace(equalRegionsDualCellColumns); }
+    SECTION("CellColumns: dual mesh, cubedsphere") { testFunctionSpace(cubedSphereDualCellColumns); }
     SECTION("NodeColumns: dual mesh, equal_regions") { testFunctionSpace(equalRegionsDualNodeColumns); }
     SECTION("NodeColumns: dual mesh, cubedsphere") { testFunctionSpace(cubedSphereDualNodeColumns); }
 }

--- a/src/tests/mesh/test_cubedsphere_meshgen.cc
+++ b/src/tests/mesh/test_cubedsphere_meshgen.cc
@@ -419,7 +419,7 @@ CASE("cubedsphere_dual_mesh_test") {
         // Set grid, mesh and functionspace.
         const auto grid = Grid("CS-LFR-C-48");
         const auto mesh =
-            MeshGenerator("cubedsphere_dual", util::Config("partitioner", "equal_regions") | util::Config("halo", 3)).generate(grid);
+            MeshGenerator("cubedsphere_dual", util::Config("halo", 3)).generate(grid);
         const auto functionSpace = functionspace::CellColumns(mesh);
         auto field =
             functionSpace.createField<double>(util::Config("name", "targetField") | util::Config("levels", nLevels));
@@ -455,6 +455,9 @@ CASE("cubedsphere_dual_mesh_test") {
         }
 
         // gmsh output.
+        auto fieldSet = FieldSet{field};
+        fieldSet.add(mesh.cells().halo());
+
         const auto gmshConfigXy =
             util::Config("coordinates", "xy") | util::Config("ghost", true) | util::Config("info", true);
         const auto gmshConfigXyz =
@@ -463,8 +466,8 @@ CASE("cubedsphere_dual_mesh_test") {
         auto gmshXyz = output::Gmsh("dual_cells_xyz.msh", gmshConfigXyz);
         gmshXy.write(mesh);
         gmshXyz.write(mesh);
-        gmshXy.write(FieldSet{field}, functionSpace);
-        gmshXyz.write(FieldSet{field}, functionSpace);
+        gmshXy.write(fieldSet, functionSpace);
+        gmshXyz.write(fieldSet, functionSpace);
     }
 }
 


### PR DESCRIPTION
This PR add functionality to the dual mesh halo. Now, the halo size can be set to any value < N-1, where N is the grid-size of a cubed sphere tile. This allows arbitrary-sized stencil operations to work on the cubed-sphere dual mesh.

An example of a cubed sphere dual mesh partition (8 PEs, default partitioner) with a halo of 3 is shown below.

![dual-halo-2d](https://user-images.githubusercontent.com/20695114/149561824-b3150b0a-6f6f-4f73-9b07-bece16e6b143.png)
xy projection of an N48 partition with a halo of 3.

![dual-halo-3d](https://user-images.githubusercontent.com/20695114/149561941-9c6be0ec-a022-4404-abe1-ac95b20ac387.png)
xyz projection of an N48 partition with a halo of 3.


I've updated several of the existing cubed sphere dual mesh tests to use larger halo sizes.