### PR TITLE
branch feature/um: explicitly look for Python 3

### DIFF
--- a/cmake/features/FORTRAN.cmake
+++ b/cmake/features/FORTRAN.cmake
@@ -29,4 +29,4 @@ if( atlas_HAVE_FORTRAN )
 
 endif()
 
-ecbuild_find_python()
+ecbuild_find_python(VERSION 3)


### PR DESCRIPTION
## Description

Small change that tells ecbuild to explicitly look for Python 3 as Python 2 is deprecated and no longer supported, but still lingering around on many systems.

### Issue(s) addressed

Fixes https://github.com/JCSDA-internal/atlas/issues/91.

## Acceptance Criteria (Definition of Done)

atlas uses Python 3 even if Python 2 is available and the default `python` on the system.

## Dependencies

None

## Impact

None. All systems have Python 3 available, it is used in many other parts of the bundle.