### PR TITLE
Change branch order to fix MPI branching mismatch

### DIFF
--- a/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
+++ b/src/atlas/interpolation/method/sphericalvector/SphericalVector.cc
@@ -149,15 +149,15 @@ void SphericalVector::do_execute(const Field& sourceField, Field& targetField,
                                  Metadata&) const {
   ATLAS_TRACE("atlas::interpolation::method::SphericalVector::do_execute()");
 
-  if (targetField.size() == 0) {
-    haloExchange(sourceField);
-    return;
-  }
-
   const auto fieldType = sourceField.metadata().getString("type", "");
   if (fieldType != "vector") {
     auto metadata = Metadata();
     Method::do_execute(sourceField, targetField, metadata);
+    return;
+  }
+
+  if (targetField.size() == 0) {
+    haloExchange(sourceField);
     return;
   }
 
@@ -193,15 +193,15 @@ void SphericalVector::do_execute_adjoint(Field& sourceField,
   ATLAS_TRACE(
       "atlas::interpolation::method::SphericalVector::do_execute_adjoint()");
 
-  if (targetField.size() == 0) {
-    adjointHaloExchange(sourceField);
-    return;
-  }
-
   const auto fieldType = sourceField.metadata().getString("type", "");
   if (fieldType != "vector") {
     auto metadata = Metadata();
     Method::do_execute_adjoint(sourceField, targetField, metadata);
+    return;
+  }
+
+  if (targetField.size() == 0) {
+    adjointHaloExchange(sourceField);
     return;
   }
 


### PR DESCRIPTION
## Description

Fixes an issue encountered with lfric-jedi 3dfgat_atms where some MPI ranks go down different `if` branches. Changing the order so that the scalar `Method` is returned first fixes the problem. Potentially the issue is due to checks that `Method` performs that call halo exchanges. Returning early with `Method` ensures that the additional logic in SphericalVector does not interfere.

## Dependencies

For ecmwf/atlas/pull/351

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
